### PR TITLE
refactor(core): store directive defs in static data

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -143,10 +143,12 @@ export function renderComponent<T>(
   const renderer = opts.renderer || document;
   const componentDef = componentType.ngComponentDef;
   let component: T;
-  const oldView = enterView(createViewState(-1, renderer), null);
+  const oldView = enterView(createViewState(-1, renderer, []), null);
   try {
-    elementHost(opts.host || componentDef.tag);
-    component = directiveCreate(0, componentDef.n(), componentDef);
+    // Create element node at index 0 in data array
+    elementHost(opts.host || componentDef.tag, componentDef);
+    // Create directive instance with n() and store at index 1 in data array (el is 0)
+    component = directiveCreate(1, componentDef.n(), componentDef);
   } finally {
     leaveView(oldView);
   }
@@ -165,7 +167,9 @@ export function detectChanges<T>(component: T) {
   ngDevMode && assertNotNull(hostNode.data, 'hostNode.data');
   const oldView = enterView(hostNode.view !, hostNode);
   try {
-    (component.constructor as ComponentType<T>).ngComponentDef.r(0, 0);
+    // Element was stored at 0 and directive was stored at 1 in renderComponent
+    // so to refresh the component, r() needs to be called with (1, 0)
+    (component.constructor as ComponentType<T>).ngComponentDef.r(1, 0);
     isDirty = false;
   } finally {
     leaveView(oldView);

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -9,7 +9,7 @@
 import {ComponentFactory, ComponentRef as IComponentRef, ElementRef as IElementRef, EmbeddedViewRef as IEmbeddedViewRef, Injector, NgModuleRef as INgModuleRef, TemplateRef as ITemplateRef, Type, ViewContainerRef as IViewContainerRef, ViewRef as IViewRef} from '../core';
 import {BLOOM_SIZE, NG_ELEMENT_ID, getOrCreateNodeInjector} from './instructions';
 import {LContainer, LNodeFlags, LNodeInjector} from './interfaces';
-import {ComponentTemplate} from './public_interfaces';
+import {ComponentTemplate, DirectiveDef} from './public_interfaces';
 import {stringify} from './util';
 
 export const enum InjectFlags {
@@ -43,13 +43,11 @@ export function inject<T>(token: Type<T>, flags?: InjectFlags): T {
         if (size !== 0) {
           size = size >> LNodeFlags.SIZE_SHIFT;
           const start = flags >> LNodeFlags.INDX_SHIFT;
-          const directives = node.view.directives;
-          if (directives) {
-            for (let i = start, ii = start + size; i < ii; i++) {
-              const def = directives[(i << 1) | 1];
-              if (def.diPublic && def.type == token) {
-                return directives[i << 1];
-              }
+          const ngStaticData = node.view.ngStaticData;
+          for (let i = start, ii = start + size; i < ii; i++) {
+            const def = ngStaticData[i] as DirectiveDef<any>;
+            if (def.diPublic && def.type == token) {
+              return node.view.data[i];
             }
           }
         }

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -10,6 +10,7 @@ import {Observable} from 'rxjs/Observable';
 import {QueryList as IQueryList, Type} from '../core';
 import {assertNotNull} from './assert';
 import {LContainer, LNode, LNodeFlags, LView, QueryState} from './interfaces';
+import {DirectiveDef} from '@angular/core/src/render3/public_interfaces';
 
 
 
@@ -101,14 +102,14 @@ function add(predicate: QueryPredicate<any>| null, node: LNode) {
   while (predicate) {
     const type = predicate.type;
     if (type) {
-      const directives = node.view.directives;
+      const ngStaticData = node.view.ngStaticData;
       const flags = node.flags;
       for (let i = flags >> LNodeFlags.INDX_SHIFT,
                ii = i + ((flags & LNodeFlags.SIZE_MASK) >> LNodeFlags.SIZE_SHIFT);
            i < ii; i++) {
-        const def = directives[i << 1 | 1];
+        const def = ngStaticData[i] as DirectiveDef<any>;
         if (def.diPublic && def.type === type) {
-          predicate.values.push(directives[i << 1]);
+          predicate.values.push(node.view.data[i]);
         }
       }
     }

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -32,12 +32,12 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(1, 'content');
+          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+          T(2, 'content');
         }
         e();
       }
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -54,12 +54,12 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(1, 'content');
+          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+          T(2, 'content');
         }
         e();
       }
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content</child>');
@@ -79,26 +79,26 @@ describe('content projection', () => {
         m(0, dP());
         E(1, GrandChild.ngComponentDef);
         {
-          D(0, GrandChild.ngComponentDef.n(), GrandChild.ngComponentDef);
-          P(2, 0);
+          D(2, GrandChild.ngComponentDef.n(), GrandChild.ngComponentDef);
+          P(3, 0);
         }
         e();
-        GrandChild.ngComponentDef.r(0, 1);
+        GrandChild.ngComponentDef.r(2, 1);
       }
     });
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-          E(1, 'b');
-          T(2, 'Hello');
+          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+          E(2, 'b');
+          T(3, 'Hello');
           e();
-          T(3, 'World!');
+          T(4, 'World!');
         }
         e();
       }
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -118,15 +118,15 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(1, '(');
-          C(2);
+          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+          T(2, '(');
+          C(3);
           c();
-          T(3, ')');
+          T(4, ')');
         }
         e();
       }
-      rC(2);
+      rC(3);
       {
         if (ctx.value) {
           if (V(0)) {
@@ -136,7 +136,7 @@ describe('content projection', () => {
         }
       }
       rc();
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>()</div></child>');
@@ -159,13 +159,13 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-          C(1);
+          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+          C(2);
           c();
         }
         e();
       }
-      rC(1);
+      rC(2);
       {
         if (ctx.value) {
           if (V(0)) {
@@ -175,7 +175,7 @@ describe('content projection', () => {
         }
       }
       rc();
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child></child>');
@@ -202,15 +202,15 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(1, '(');
-          C(2);
+          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+          T(2, '(');
+          C(3);
           c();
-          T(3, ')');
+          T(4, ')');
         }
         e();
       }
-      rC(2);
+      rC(3);
       {
         if (ctx.value) {
           if (V(0)) {
@@ -225,7 +225,7 @@ describe('content projection', () => {
         }
       }
       rc();
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>(else)</div></child>');
@@ -280,12 +280,12 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(1, 'content');
+          D(1, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
+          T(2, 'content');
         }
         e();
       }
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div><span>content</span></div></child>');
@@ -335,12 +335,12 @@ describe('content projection', () => {
          if (cm) {
            E(0, Child.ngComponentDef);
            {
-             D(0, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
-             T(1, 'content');
+             D(1, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
+             T(2, 'content');
            }
            e();
          }
-         Child.ngComponentDef.r(0, 0);
+         Child.ngComponentDef.r(1, 0);
        });
        const parent = renderComponent(Parent);
        expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -374,12 +374,12 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(1, 'content');
+          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+          T(2, 'content');
         }
         e();
       }
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div></div><span>content</span></child>');
@@ -434,12 +434,12 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child.ngComponentDef);
         {
-          D(0, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(1, 'content');
+          D(1, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
+          T(2, 'content');
         }
         e();
       }
-      Child.ngComponentDef.r(0, 0);
+      Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content<div></div></child>');
@@ -479,17 +479,17 @@ describe('content projection', () => {
         if (cm) {
           E(0, Child.ngComponentDef);
           {
-            D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-            E(1, 'span', ['title', 'toFirst']);
-            { T(2, '1'); }
+            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+            E(2, 'span', ['title', 'toFirst']);
+            { T(3, '1'); }
             e();
-            E(3, 'span', ['title', 'toSecond']);
-            { T(4, '2'); }
+            E(4, 'span', ['title', 'toSecond']);
+            { T(5, '2'); }
             e();
           }
           e();
         }
-        Child.ngComponentDef.r(0, 0);
+        Child.ngComponentDef.r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -526,17 +526,17 @@ describe('content projection', () => {
         if (cm) {
           E(0, Child.ngComponentDef);
           {
-            D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-            E(1, 'span', ['class', 'toFirst']);
-            { T(2, '1'); }
+            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+            E(2, 'span', ['class', 'toFirst']);
+            { T(3, '1'); }
             e();
-            E(3, 'span', ['class', 'toSecond']);
-            { T(4, '2'); }
+            E(4, 'span', ['class', 'toSecond']);
+            { T(5, '2'); }
             e();
           }
           e();
         }
-        Child.ngComponentDef.r(0, 0);
+        Child.ngComponentDef.r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -573,17 +573,17 @@ describe('content projection', () => {
         if (cm) {
           E(0, Child.ngComponentDef);
           {
-            D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-            E(1, 'span', ['class', 'other toFirst']);
-            { T(2, '1'); }
+            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+            E(2, 'span', ['class', 'other toFirst']);
+            { T(3, '1'); }
             e();
-            E(3, 'span', ['class', 'toSecond noise']);
-            { T(4, '2'); }
+            E(4, 'span', ['class', 'toSecond noise']);
+            { T(5, '2'); }
             e();
           }
           e();
         }
-        Child.ngComponentDef.r(0, 0);
+        Child.ngComponentDef.r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -619,17 +619,17 @@ describe('content projection', () => {
         if (cm) {
           E(0, Child.ngComponentDef);
           {
-            D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-            E(1, 'span', ['class', 'toFirst']);
-            { T(2, '1'); }
+            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+            E(2, 'span', ['class', 'toFirst']);
+            { T(3, '1'); }
             e();
-            E(3, 'span', ['class', 'toSecond']);
-            { T(4, '2'); }
+            E(4, 'span', ['class', 'toSecond']);
+            { T(5, '2'); }
             e();
           }
           e();
         }
-        Child.ngComponentDef.r(0, 0);
+        Child.ngComponentDef.r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -665,18 +665,18 @@ describe('content projection', () => {
         if (cm) {
           E(0, Child.ngComponentDef);
           {
-            D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-            E(1, 'span', ['class', 'toFirst']);
-            { T(2, '1'); }
+            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+            E(2, 'span', ['class', 'toFirst']);
+            { T(3, '1'); }
             e();
-            E(3, 'span');
-            { T(4, 'remaining'); }
+            E(4, 'span');
+            { T(5, 'remaining'); }
             e();
-            T(5, 'more remaining');
+            T(6, 'more remaining');
           }
           e();
         }
-        Child.ngComponentDef.r(0, 0);
+        Child.ngComponentDef.r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -713,14 +713,14 @@ describe('content projection', () => {
         if (cm) {
           E(0, Child.ngComponentDef);
           {
-            D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-            E(1, 'span');
-            { T(2, '1'); }
+            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+            E(2, 'span');
+            { T(3, '1'); }
             e();
-            E(3, 'span', ['class', 'toSecond']);
-            { T(4, '2'); }
+            E(4, 'span', ['class', 'toSecond']);
+            { T(5, '2'); }
             e();
-            T(5, 'remaining');
+            T(6, 'remaining');
           }
           e();
         }
@@ -765,14 +765,14 @@ describe('content projection', () => {
           m(0, dP());
           E(1, GrandChild.ngComponentDef);
           {
-            D(0, GrandChild.ngComponentDef.n(), GrandChild.ngComponentDef);
-            P(2, 0);
-            E(3, 'span');
-            { T(4, 'in child template'); }
+            D(2, GrandChild.ngComponentDef.n(), GrandChild.ngComponentDef);
+            P(3, 0);
+            E(4, 'span');
+            { T(5, 'in child template'); }
             e();
           }
           e();
-          GrandChild.ngComponentDef.r(0, 1);
+          GrandChild.ngComponentDef.r(2, 1);
         }
       });
 
@@ -787,14 +787,14 @@ describe('content projection', () => {
         if (cm) {
           E(0, Child.ngComponentDef);
           {
-            D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-            E(1, 'span');
-            { T(2, 'parent content'); }
+            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+            E(2, 'span');
+            { T(3, 'parent content'); }
             e();
           }
           e();
         }
-        Child.ngComponentDef.r(0, 0);
+        Child.ngComponentDef.r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -828,13 +828,13 @@ describe('content projection', () => {
         if (cm) {
           E(0, Child.ngComponentDef);
           {
-            D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-            C(1, undefined, 'div');
+            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
+            C(2, undefined, 'div');
             c();
           }
           e();
         }
-        rC(1);
+        rC(2);
         {
           if (true) {
             if (V(0)) {
@@ -846,7 +846,7 @@ describe('content projection', () => {
           }
         }
         rc();
-        Child.ngComponentDef.r(0, 0);
+        Child.ngComponentDef.r(1, 0);
       });
       const parent = renderComponent(Parent);
       expect(toHtml(parent)).toEqual('<child><span><div>content</div></span></child>');

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -27,12 +27,12 @@ describe('di', () => {
         if (cm) {
           E(0, 'div');
           {
-            D(0, DirectiveDef.n(), DirectiveDef);
-            T(1);
+            D(1, DirectiveDef.n(), DirectiveDef);
+            T(2);
           }
           e();
         }
-        t(1, b(D<Directive>(0).value));
+        t(2, b(D<Directive>(1).value));
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div>Created</div>');
@@ -66,18 +66,18 @@ describe('di', () => {
         if (cm) {
           E(0, 'div');
           {
-            D(0, DirectiveADef.n(), DirectiveADef);
-            E(1, 'span');
+            D(1, DirectiveADef.n(), DirectiveADef);
+            E(2, 'span');
             {
-              D(1, DirectiveBDef.n(), DirectiveBDef);
-              D(2, DirectiveCDef.n(), DirectiveCDef);
-              T(2);
+              D(3, DirectiveBDef.n(), DirectiveBDef);
+              D(4, DirectiveCDef.n(), DirectiveCDef);
+              T(5);
             }
             e();
           }
           e();
         }
-        t(2, b(D<DirectiveC>(2).value));
+        t(5, b(D<DirectiveC>(4).value));
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div><span>AB</span></div>');
@@ -113,13 +113,13 @@ describe('di', () => {
         if (cm) {
           E(0, 'div');
           {
-            D(0, DirectiveDef.n(), DirectiveDef);
-            D(1, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
-            T(1);
+            D(1, DirectiveDef.n(), DirectiveDef);
+            D(2, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
+            T(3);
           }
           e();
         }
-        t(1, b2('', D<Directive>(0).value, '-', D<DirectiveSameInstance>(1).value, ''));
+        t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div>ElementRef-true</div>');
@@ -156,13 +156,13 @@ describe('di', () => {
         if (cm) {
           C(0, function() {});
           {
-            D(0, DirectiveDef.n(), DirectiveDef);
-            D(1, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
+            D(1, DirectiveDef.n(), DirectiveDef);
+            D(2, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
           }
           c();
-          T(1);
+          T(3);
         }
-        t(1, b2('', D<Directive>(0).value, '-', D<DirectiveSameInstance>(1).value, ''));
+        t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
       }
 
       expect(renderToHtml(Template, {})).toEqual('TemplateRef-true');
@@ -198,13 +198,13 @@ describe('di', () => {
         if (cm) {
           E(0, 'div');
           {
-            D(0, DirectiveDef.n(), DirectiveDef);
-            D(1, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
-            T(1);
+            D(1, DirectiveDef.n(), DirectiveDef);
+            D(2, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
+            T(3);
           }
           e();
         }
-        t(1, b2('', D<Directive>(0).value, '-', D<DirectiveSameInstance>(1).value, ''));
+        t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div>ViewContainerRef-true</div>');
@@ -285,24 +285,24 @@ describe('di', () => {
         if (cm) {
           E(0, 'div');
           {
-            D(0, ParentDirectiveDef.n(), ParentDirectiveDef);
-            C(1);
+            D(1, ParentDirectiveDef.n(), ParentDirectiveDef);
+            C(2);
             c();
           }
           e();
         }
-        rC(1);
+        rC(2);
         {
           if (V(0)) {
             E(0, 'span');
             {
-              D(0, ChildDirectiveDef.n(), ChildDirectiveDef);
-              D(1, Child2DirectiveDef.n(), Child2DirectiveDef);
-              T(1);
+              D(1, ChildDirectiveDef.n(), ChildDirectiveDef);
+              D(2, Child2DirectiveDef.n(), Child2DirectiveDef);
+              T(3);
             }
             e();
           }
-          t(1, b2('', D<ChildDirective>(0).value, '-', D<Child2Directive>(1).value, ''));
+          t(3, b2('', D<ChildDirective>(1).value, '-', D<Child2Directive>(2).value, ''));
           v();
         }
         rc();
@@ -318,7 +318,7 @@ describe('di', () => {
 
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
-      const contentView = createViewState(-1, null !);
+      const contentView = createViewState(-1, null !, []);
       const oldView = enterView(contentView, null !);
       try {
         const parent = createLNode(0, LNodeFlags.Element, null, null);

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -31,10 +31,10 @@ describe('directive', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'span');
-          { D(0, DirectiveDef.n(), DirectiveDef); }
+          { D(1, DirectiveDef.n(), DirectiveDef); }
           e();
         }
-        DirectiveDef.r(0, 0);
+        DirectiveDef.r(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<span class="foo"></span>');

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -33,11 +33,11 @@ describe('exports', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, MyComponent.ngComponentDef);
-        { D(0, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
+        { D(1, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
         e();
-        T(1);
+        T(2);
       }
-      t(1, D<MyComponent>(0).name);
+      t(2, D<MyComponent>(1).name);
     }
 
     class MyComponent {
@@ -79,13 +79,13 @@ describe('exports', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, MyComponent.ngComponentDef);
-        { D(0, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
+        { D(1, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
         e();
-        E(1, 'div');
-        { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+        E(2, 'div');
+        { D(3, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
         e();
       }
-      p(1, 'myDir', b(D<MyComponent>(0)));
+      p(2, 'myDir', b(D<MyComponent>(1)));
     }
 
     renderToHtml(Template, {});
@@ -98,11 +98,11 @@ describe('exports', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, 'div');
-        D(0, SomeDirDef.n(), SomeDirDef);
+        D(1, SomeDirDef.n(), SomeDirDef);
         e();
-        T(1);
+        T(2);
       }
-      t(1, D<SomeDir>(0).name);
+      t(2, D<SomeDir>(1).name);
     }
 
     class SomeDir {
@@ -208,13 +208,13 @@ describe('exports', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'div');
-          { D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
           e();
-          E(1, MyComponent.ngComponentDef);
-          { D(1, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
+          E(2, MyComponent.ngComponentDef);
+          { D(3, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
           e();
         }
-        p(0, 'myDir', b(D<MyComponent>(1)));
+        p(0, 'myDir', b(D<MyComponent>(3)));
       }
 
       renderToHtml(Template, {});
@@ -229,13 +229,13 @@ describe('exports', () => {
           T(0);
           T(1);
           E(2, 'comp');
-          { D(0, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
+          { D(3, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
           e();
-          E(3, 'input', ['value', 'one']);
+          E(4, 'input', ['value', 'one']);
           e();
         }
-        let myInput = E(3);
-        let myComp = D(0) as MyComponent;
+        let myInput = E(4);
+        let myComp = D(3) as MyComponent;
         t(0, b(myInput && (myInput as any).value));
         t(1, b(myComp && myComp.name));
       }

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -231,10 +231,10 @@ describe('iv integration test', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, TodoComponent.ngComponentDef);
-          { D(0, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
+          { D(1, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
           e();
         }
-        TodoComponent.ngComponentDef.r(0, 0);
+        TodoComponent.ngComponentDef.r(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>');
@@ -244,11 +244,11 @@ describe('iv integration test', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, TodoComponent.ngComponentDef);
-          { D(0, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
+          { D(1, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
           e();
-          T(1, 'two');
+          T(2, 'two');
         }
-        TodoComponent.ngComponentDef.r(0, 0);
+        TodoComponent.ngComponentDef.r(1, 0);
       }
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>two');
     });
@@ -261,14 +261,14 @@ describe('iv integration test', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, TodoComponent.ngComponentDef);
-          { D(0, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
-          e();
-          E(1, TodoComponent.ngComponentDef);
           { D(1, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
           e();
+          E(2, TodoComponent.ngComponentDef);
+          { D(3, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
+          e();
         }
-        TodoComponent.ngComponentDef.r(0, 0);
-        TodoComponent.ngComponentDef.r(1, 1);
+        TodoComponent.ngComponentDef.r(1, 0);
+        TodoComponent.ngComponentDef.r(3, 2);
       }
       expect(renderToHtml(Template, null))
           .toEqual('<todo><p>Todo one</p></todo><todo><p>Todo one</p></todo>');
@@ -303,12 +303,12 @@ describe('iv integration test', () => {
         if (cm) {
           E(0, TodoComponentHostBinding.ngComponentDef);
           {
-            D(0, TodoComponentHostBinding.ngComponentDef.n(),
+            D(1, TodoComponentHostBinding.ngComponentDef.n(),
               TodoComponentHostBinding.ngComponentDef);
           }
           e();
         }
-        TodoComponentHostBinding.ngComponentDef.r(0, 0);
+        TodoComponentHostBinding.ngComponentDef.r(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<todo title="one">one</todo>');
@@ -338,10 +338,10 @@ describe('iv integration test', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, MyComp.ngComponentDef);
-          { D(0, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
+          { D(1, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
           e();
         }
-        MyComp.ngComponentDef.r(0, 0);
+        MyComp.ngComponentDef.r(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<comp><p>Bess</p></comp>');
@@ -385,11 +385,11 @@ describe('iv integration test', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, MyComp.ngComponentDef);
-          { D(0, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
+          { D(1, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
           e();
         }
         p(0, 'condition', b(ctx.condition));
-        MyComp.ngComponentDef.r(0, 0);
+        MyComp.ngComponentDef.r(1, 0);
       }
 
       expect(renderToHtml(Template, {condition: true})).toEqual('<comp><div>text</div></comp>');

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -20,10 +20,10 @@ describe('lifecycles', () => {
     let Parent = createOnDestroyComponent('parent', function(ctx: any, cm: boolean) {
       if (cm) {
         E(0, Comp.ngComponentDef);
-        { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+        { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
         e();
       }
-      Comp.ngComponentDef.r(0, 0);
+      Comp.ngComponentDef.r(1, 0);
     });
 
     function createOnDestroyComponent(name: string, template: ComponentTemplate<any>) {
@@ -62,10 +62,10 @@ describe('lifecycles', () => {
           if (ctx.condition) {
             if (V(0)) {
               E(0, Comp.ngComponentDef);
-              { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
               e();
             }
-            Comp.ngComponentDef.r(0, 0);
+            Comp.ngComponentDef.r(1, 0);
             v();
           }
         }
@@ -95,16 +95,16 @@ describe('lifecycles', () => {
           if (ctx.condition) {
             if (V(0)) {
               E(0, Comp.ngComponentDef);
-              { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
-              e();
-              E(1, Comp.ngComponentDef);
               { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              e();
+              E(2, Comp.ngComponentDef);
+              { D(3, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
               e();
             }
             p(0, 'val', b('1'));
-            p(1, 'val', b('2'));
-            Comp.ngComponentDef.r(0, 0);
-            Comp.ngComponentDef.r(1, 1);
+            p(2, 'val', b('2'));
+            Comp.ngComponentDef.r(1, 0);
+            Comp.ngComponentDef.r(3, 2);
             v();
           }
         }
@@ -135,10 +135,10 @@ describe('lifecycles', () => {
           if (ctx.condition) {
             if (V(0)) {
               E(0, Parent.ngComponentDef);
-              { D(0, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+              { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
               e();
             }
-            Parent.ngComponentDef.r(0, 0);
+            Parent.ngComponentDef.r(1, 0);
             v();
           }
         }
@@ -163,10 +163,10 @@ describe('lifecycles', () => {
       let Grandparent = createOnDestroyComponent('grandparent', function(ctx: any, cm: boolean) {
         if (cm) {
           E(0, Parent.ngComponentDef);
-          { D(0, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
           e();
         }
-        Parent.ngComponentDef.r(0, 0);
+        Parent.ngComponentDef.r(1, 0);
       });
 
       function Template(ctx: any, cm: boolean) {
@@ -179,10 +179,10 @@ describe('lifecycles', () => {
           if (ctx.condition) {
             if (V(0)) {
               E(0, Grandparent.ngComponentDef);
-              { D(0, Grandparent.ngComponentDef.n(), Grandparent.ngComponentDef); }
+              { D(1, Grandparent.ngComponentDef.n(), Grandparent.ngComponentDef); }
               e();
             }
-            Grandparent.ngComponentDef.r(0, 0);
+            Grandparent.ngComponentDef.r(1, 0);
             v();
           }
         }
@@ -216,32 +216,32 @@ describe('lifecycles', () => {
           if (ctx.condition) {
             if (V(0)) {
               E(0, Comp.ngComponentDef);
-              { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
-              e();
-              C(1);
-              c();
-              E(2, Comp.ngComponentDef);
               { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              e();
+              C(2);
+              c();
+              E(3, Comp.ngComponentDef);
+              { D(4, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
               e();
             }
             p(0, 'val', b('1'));
-            Comp.ngComponentDef.r(0, 0);
-            rC(1);
+            Comp.ngComponentDef.r(1, 0);
+            rC(2);
             {
               if (ctx.condition2) {
                 if (V(0)) {
                   E(0, Comp.ngComponentDef);
-                  { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+                  { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
                   e();
                 }
                 p(0, 'val', b('2'));
-                Comp.ngComponentDef.r(0, 0);
+                Comp.ngComponentDef.r(1, 0);
                 v();
               }
             }
             rc();
-            p(2, 'val', b('3'));
-            Comp.ngComponentDef.r(1, 2);
+            p(3, 'val', b('3'));
+            Comp.ngComponentDef.r(4, 3);
             v();
           }
         }
@@ -294,32 +294,32 @@ describe('lifecycles', () => {
           if (ctx.condition) {
             if (V(0)) {
               E(0, Comp.ngComponentDef);
-              { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
-              e();
-              C(1);
-              c();
-              E(2, Comp.ngComponentDef);
               { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              e();
+              C(2);
+              c();
+              E(3, Comp.ngComponentDef);
+              { D(4, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
               e();
             }
             p(0, 'val', b('1'));
-            Comp.ngComponentDef.r(0, 0);
-            rC(1);
+            Comp.ngComponentDef.r(1, 0);
+            rC(2);
             {
               for (let j = 2; j < ctx.len; j++) {
                 if (V(0)) {
                   E(0, Comp.ngComponentDef);
-                  { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+                  { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
                   e();
                 }
                 p(0, 'val', b(j));
-                Comp.ngComponentDef.r(0, 0);
+                Comp.ngComponentDef.r(1, 0);
                 v();
               }
             }
             rc();
-            p(2, 'val', b('5'));
-            Comp.ngComponentDef.r(1, 2);
+            p(3, 'val', b('5'));
+            Comp.ngComponentDef.r(4, 3);
             v();
           }
         }
@@ -380,16 +380,16 @@ describe('lifecycles', () => {
               }
               e();
               E(2, Comp.ngComponentDef);
-              { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              { D(3, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
               e();
-              E(3, 'button');
+              E(4, 'button');
               {
                 L('click', ctx.onClick.bind(ctx));
-                T(4, 'Click me');
+                T(5, 'Click me');
               }
               e();
             }
-            Comp.ngComponentDef.r(0, 2);
+            Comp.ngComponentDef.r(3, 2);
             v();
           }
         }

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -204,14 +204,14 @@ describe('event listeners', () => {
           if (V(0)) {
             T(0, 'Hello');
             E(1, MyComp.ngComponentDef);
-            { D(0, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
+            { D(2, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
             e();
-            E(2, MyComp.ngComponentDef);
-            { D(1, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
+            E(3, MyComp.ngComponentDef);
+            { D(4, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
             e();
           }
-          MyComp.ngComponentDef.r(0, 1);
-          MyComp.ngComponentDef.r(1, 2);
+          MyComp.ngComponentDef.r(2, 1);
+          MyComp.ngComponentDef.r(4, 3);
           v();
         }
       }

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -16,7 +16,7 @@ function testLStaticData(tagName: string, attrs: string[] | null): LNodeStatic {
     initialInputs: undefined,
     inputs: undefined,
     outputs: undefined,
-    containerStatic: null
+    containerStatic: null,
   };
 }
 

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -46,12 +46,12 @@ describe('outputs', () => {
       if (cm) {
         E(0, ButtonToggle.ngComponentDef);
         {
-          D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
           L('change', ctx.onChange.bind(ctx));
         }
         e();
       }
-      ButtonToggle.ngComponentDef.r(0, 0);
+      ButtonToggle.ngComponentDef.r(1, 0);
     }
 
     let counter = 0;
@@ -71,13 +71,13 @@ describe('outputs', () => {
       if (cm) {
         E(0, ButtonToggle.ngComponentDef);
         {
-          D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
           L('change', ctx.onChange.bind(ctx));
           L('reset', ctx.onReset.bind(ctx));
         }
         e();
       }
-      ButtonToggle.ngComponentDef.r(0, 0);
+      ButtonToggle.ngComponentDef.r(1, 0);
     }
 
     let counter = 0;
@@ -98,12 +98,12 @@ describe('outputs', () => {
       if (cm) {
         E(0, ButtonToggle.ngComponentDef);
         {
-          D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
           L('change', () => ctx.counter++);
         }
         e();
       }
-      ButtonToggle.ngComponentDef.r(0, 0);
+      ButtonToggle.ngComponentDef.r(1, 0);
     }
 
     const ctx = {counter: 0};
@@ -135,12 +135,12 @@ describe('outputs', () => {
           if (V(0)) {
             E(0, ButtonToggle.ngComponentDef);
             {
-              D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+              D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
               L('change', ctx.onChange.bind(ctx));
             }
             e();
           }
-          ButtonToggle.ngComponentDef.r(0, 0);
+          ButtonToggle.ngComponentDef.r(1, 0);
           v();
         }
       }
@@ -189,12 +189,12 @@ describe('outputs', () => {
               if (V(0)) {
                 E(0, ButtonToggle.ngComponentDef);
                 {
-                  D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+                  D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
                   L('change', ctx.onChange.bind(ctx));
                 }
                 e();
               }
-              ButtonToggle.ngComponentDef.r(0, 0);
+              ButtonToggle.ngComponentDef.r(1, 0);
               v();
             }
           }
@@ -262,16 +262,16 @@ describe('outputs', () => {
             e();
             E(2, ButtonToggle.ngComponentDef);
             {
-              D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+              D(3, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
               L('change', ctx.onChange.bind(ctx));
             }
             e();
-            E(3, DestroyComp.ngComponentDef);
-            { D(1, DestroyComp.ngComponentDef.n(), DestroyComp.ngComponentDef); }
+            E(4, DestroyComp.ngComponentDef);
+            { D(5, DestroyComp.ngComponentDef.n(), DestroyComp.ngComponentDef); }
             e();
           }
-          ButtonToggle.ngComponentDef.r(0, 2);
-          DestroyComp.ngComponentDef.r(1, 3);
+          ButtonToggle.ngComponentDef.r(3, 2);
+          DestroyComp.ngComponentDef.r(5, 4);
           v();
         }
       }
@@ -318,7 +318,7 @@ describe('outputs', () => {
       if (cm) {
         E(0, 'button');
         {
-          D(0, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
+          D(1, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
           L('click', ctx.onClick.bind(ctx));
         }
         e();
@@ -344,13 +344,13 @@ describe('outputs', () => {
       if (cm) {
         E(0, ButtonToggle.ngComponentDef);
         {
-          D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-          D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
+          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+          D(2, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
           L('change', ctx.onChange.bind(ctx));
         }
         e();
       }
-      ButtonToggle.ngComponentDef.r(0, 0);
+      ButtonToggle.ngComponentDef.r(1, 0);
     }
 
     let counter = 0;
@@ -378,14 +378,14 @@ describe('outputs', () => {
       if (cm) {
         E(0, ButtonToggle.ngComponentDef);
         {
-          D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-          D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
+          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+          D(2, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
           L('change', ctx.onChange.bind(ctx));
         }
         e();
       }
       p(0, 'change', b(ctx.change));
-      ButtonToggle.ngComponentDef.r(0, 0);
+      ButtonToggle.ngComponentDef.r(1, 0);
     }
 
     let counter = 0;
@@ -426,17 +426,18 @@ describe('outputs', () => {
           if (V(0)) {
             E(0, ButtonToggle.ngComponentDef);
             {
-              D(0, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
+              D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
               L('change', ctx.onChange.bind(ctx));
             }
             e();
           }
+          ButtonToggle.ngComponentDef.r(1, 0);
           v();
         } else {
           if (V(1)) {
             E(0, 'div');
             {
-              D(0, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
+              D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
               L('change', ctx.onChange.bind(ctx));
             }
             e();

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -92,9 +92,9 @@ describe('elementProperty', () => {
         if (cm) {
           E(0, 'button');
           {
-            D(0, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
-            D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
-            T(1, 'Click me');
+            D(1, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
+            D(2, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
+            T(3, 'Click me');
           }
           e();
         }
@@ -122,8 +122,8 @@ describe('elementProperty', () => {
         if (cm) {
           E(0, 'button');
           {
-            D(0, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
-            T(1, 'Click me');
+            D(1, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
+            T(2, 'Click me');
           }
           e();
         }
@@ -160,11 +160,11 @@ describe('elementProperty', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, Comp.ngComponentDef);
-          { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
           e();
         }
         p(0, 'id', b(ctx.id));
-        Comp.ngComponentDef.r(0, 0);
+        Comp.ngComponentDef.r(1, 0);
       }
 
       expect(renderToHtml(Template, {id: 1})).toEqual(`<comp></comp>`);
@@ -192,9 +192,9 @@ describe('elementProperty', () => {
         if (cm) {
           E(0, 'button');
           {
-            D(0, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
-            D(1, OtherDisabledDir.ngDirectiveDef.n(), OtherDisabledDir.ngDirectiveDef);
-            T(1, 'Click me');
+            D(1, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
+            D(2, OtherDisabledDir.ngDirectiveDef.n(), OtherDisabledDir.ngDirectiveDef);
+            T(3, 'Click me');
           }
           e();
         }
@@ -218,9 +218,9 @@ describe('elementProperty', () => {
         if (cm) {
           E(0, 'button');
           {
-            D(0, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
+            D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
             L('click', ctx.onClick.bind(ctx));
-            T(1, 'Click me');
+            T(2, 'Click me');
           }
           e();
         }
@@ -262,15 +262,15 @@ describe('elementProperty', () => {
         if (cm) {
           E(0, 'button');
           {
-            D(0, IdDir.ngDirectiveDef.n(), IdDir.ngDirectiveDef);
-            T(1, 'Click me');
+            D(1, IdDir.ngDirectiveDef.n(), IdDir.ngDirectiveDef);
+            T(2, 'Click me');
           }
           e();
-          C(2);
+          C(3);
           c();
         }
         p(0, 'id', b(ctx.id1));
-        rC(2);
+        rC(3);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -284,8 +284,8 @@ describe('elementProperty', () => {
             if (V(1)) {
               E(0, 'button');
               {
-                D(0, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
-                T(1, 'Click me too');
+                D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
+                T(2, 'Click me too');
               }
               e();
             }
@@ -337,7 +337,7 @@ describe('elementProperty', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'div', ['role', 'button']);
-          { D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
           e();
         }
       }
@@ -352,7 +352,7 @@ describe('elementProperty', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'div', ['role', 'button']);
-          { D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
           e();
         }
         p(0, 'role', b(ctx.role));
@@ -372,8 +372,8 @@ describe('elementProperty', () => {
         if (cm) {
           E(0, 'div', ['role', 'button']);
           {
-            D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef);
-            D(1, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef);
+            D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef);
+            D(2, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef);
           }
           e();
         }
@@ -390,7 +390,7 @@ describe('elementProperty', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'div', ['role', 'button', 'dir', 'rtl']);
-          { D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
           e();
         }
       }
@@ -407,7 +407,7 @@ describe('elementProperty', () => {
         if (cm) {
           E(0, 'div', ['role', 'button']);
           {
-            D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef);
+            D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef);
             L('change', ctx.onChange.bind(ctx));
           }
           e();
@@ -434,10 +434,10 @@ describe('elementProperty', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'div', ['role', 'button', 'dir', 'rtl']);
-          { D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
           e();
-          E(1, 'div', ['role', 'listbox']);
-          { D(1, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef); }
+          E(2, 'div', ['role', 'listbox']);
+          { D(3, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef); }
           e();
         }
       }
@@ -462,17 +462,17 @@ describe('elementProperty', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'div', ['role', 'listbox']);
-          { D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
           e();
-          C(1);
+          C(2);
           c();
         }
-        rC(1);
+        rC(2);
         {
           if (ctx.condition) {
             if (V(0)) {
               E(0, 'div', ['role', 'button']);
-              { D(0, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef); }
+              { D(1, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef); }
               e();
             }
             v();
@@ -510,11 +510,11 @@ describe('elementProperty', () => {
           template: function(ctx: any, cm: boolean) {
             if (cm) {
               E(0, 'div', ['role', 'button']);
-              { D(0, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+              { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
               e();
-              T(1);
+              T(2);
             }
-            t(1, b(D<MyDir>(0).role));
+            t(2, b(D<MyDir>(1).role));
           },
           factory: () => new Comp()
         });
@@ -535,10 +535,10 @@ describe('elementProperty', () => {
           for (let i = 0; i < 2; i++) {
             if (V(0)) {
               E(0, Comp.ngComponentDef);
-              { D(0, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
               e();
             }
-            Comp.ngComponentDef.r(0, 0);
+            Comp.ngComponentDef.r(1, 0);
             v();
           }
         }

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -33,9 +33,9 @@ describe('query', () => {
         m(1, Q(Child, true));
         E(2, Child.ngComponentDef);
         {
-          child1 = D(0, Child.ngComponentDef.n(), Child.ngComponentDef);
-          E(3, Child.ngComponentDef);
-          { child2 = D(1, Child.ngComponentDef.n(), Child.ngComponentDef); }
+          child1 = D(3, Child.ngComponentDef.n(), Child.ngComponentDef);
+          E(4, Child.ngComponentDef);
+          { child2 = D(5, Child.ngComponentDef.n(), Child.ngComponentDef); }
           e();
         }
         e();

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -37,7 +37,7 @@ export function resetDOM() {
   requestAnimationFrame.queue = [];
   containerEl = document.createElement('div');
   containerEl.setAttribute('host', '');
-  host = createLNode(null, LNodeFlags.Element, containerEl, createViewState(-1, activeRenderer));
+  host = createLNode(null, LNodeFlags.Element, containerEl, createViewState(-1, activeRenderer, null !));
   // TODO: assert that the global state is clean (e.g. ngData, previousOrParentNode, etc)
 }
 


### PR DESCRIPTION
This PR combines the `directives` array with the main `data` array. Given that a new `directives` array was created once per view, this saves us about 70 bytes of memory for each view. Additionally, we are now storing directive definitions in the template's static data array, which will cut our storage cost in half for directives after the first template is processed. 

Notes:
- Directive instances are stored at the next available index of the `data` array. Their definitions are stored at the same index in the `ngStaticData` array.
- In generated code, directives monotonically increase with other indices and no longer have an independent numbering scheme.
- `ngStaticData` has been added to `ViewState` so DI can retrieve the correct `ngStaticData` associated with an injector (this will give it access to the directive defs stored there).

cc @jelbourn