### PR TITLE
feat: support queries for elements with local names

### DIFF
--- a/modules/benchmarks/src/largetable/render3/table.ts
+++ b/modules/benchmarks/src/largetable/render3/table.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, T, V, s, b, c, defineComponent, detectChanges, e, rC, rc, t, v} from '@angular/core/src/render3/index';
+import {C, E, T, V, b, c, defineComponent, detectChanges, e, rC, rc, s, t, v} from '@angular/core/src/render3/index';
 import {ComponentDef} from '@angular/core/src/render3/public_interfaces';
 
 import {TableCell, buildTable, emptyTable} from '../util';

--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, T, V, s, b, b1, c, defineComponent, detectChanges as _detectChanges, e, p, rC, rc, t, v} from '@angular/core/src/render3/index';
+import {C, D, E, T, V, b, b1, c, defineComponent, detectChanges as _detectChanges, e, p, rC, rc, s, t, v} from '@angular/core/src/render3/index';
 import {ComponentDef} from '@angular/core/src/render3/public_interfaces';
 
 import {TreeNode, buildTree, emptyTree} from '../util';

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -11,7 +11,7 @@
 import * as viewEngine from '../core';
 
 import {BLOOM_SIZE, NG_ELEMENT_ID, getOrCreateNodeInjector} from './instructions';
-import {LContainer, LNodeFlags, LNodeInjector} from './l_node';
+import {LContainer, LElement, LNodeFlags, LNodeInjector} from './l_node';
 import {ComponentTemplate, DirectiveDef} from './public_interfaces';
 import {notImplemented, stringify} from './util';
 
@@ -201,15 +201,23 @@ export function bloomFindPossibleInjector(
 }
 
 /**
+ * Creates an ElementRef for a given node and stores it on the injector.
+ * Or, if the ElementRef already exists, retrieves the existing ElementRef.
+ *
+ * @returns The ElementRef instance to use
+ */
+export function injectElementRefForNode(node?: LElement | LContainer): viewEngine.ElementRef {
+  let di = getOrCreateNodeInjector(node);
+  return di.elementRef || (di.elementRef = new ElementRef(di.node.native));
+}
+
+/**
  * Creates an ElementRef and stores it on the injector. Or, if the ElementRef already
  * exists, retrieves the existing ElementRef.
  *
  * @returns The ElementRef instance to use
  */
-export function injectElementRef(): viewEngine.ElementRef {
-  let di = getOrCreateNodeInjector();
-  return di.elementRef || (di.elementRef = new ElementRef(di.node.native));
-}
+export const injectElementRef: () => viewEngine.ElementRef = injectElementRefForNode;
 
 /** A ref to a node's native element. */
 class ElementRef implements viewEngine.ElementRef {

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -63,7 +63,8 @@ let nextNgElementId = 0;
  * - ObjectedOrientedRenderer3
  *
  * This is the native browser API style, e.g. operations are methods on individual objects
- * like HTMLElement. With this style, no additional code is needed as a facade (reducing payload size).
+ * like HTMLElement. With this style, no additional code is needed as a facade (reducing payload
+ * size).
  *
  * - ProceduralRenderer3
  *
@@ -437,8 +438,9 @@ function setUpAttributes(native: RElement, attrs: string[]): void {
   ngDevMode && assertEqual(attrs.length % 2, 0, 'attrs.length % 2');
   const isProceduralRenderer = (renderer as ProceduralRenderer3).setAttribute;
   for (let i = 0; i < attrs.length; i += 2) {
-    isProceduralRenderer ? (renderer as ProceduralRenderer3).setAttribute !(native, attrs[i], attrs[i | 1]) :
-                   native.setAttribute(attrs[i], attrs[i | 1]);
+    isProceduralRenderer ?
+        (renderer as ProceduralRenderer3).setAttribute !(native, attrs[i], attrs[i | 1]) :
+        native.setAttribute(attrs[i], attrs[i | 1]);
   }
 }
 
@@ -481,8 +483,7 @@ export function elementHost(elementOrSelector: RElement | string, def: Component
  * @param listener The function to be called when event emits
  * @param useCapture Whether or not to use capture in event listener.
  */
-export function listener(
-    eventName: string, listener: EventListener, useCapture = false): void {
+export function listener(eventName: string, listener: EventListener, useCapture = false): void {
   ngDevMode && assertPreviousIsParent();
   const node = previousOrParentNode;
   const native = node.native as RElement;
@@ -789,8 +790,7 @@ export function textBinding<T>(index: number, value: T | NO_CHANGE): void {
  */
 export function directive<T>(index: number): T;
 export function directive<T>(index: number, directive: T, directiveDef: DirectiveDef<T>): T;
-export function directive<T>(
-    index: number, directive?: T, directiveDef?: DirectiveDef<T>): T {
+export function directive<T>(index: number, directive?: T, directiveDef?: DirectiveDef<T>): T {
   let instance;
   if (directive == null) {
     // return existing
@@ -920,11 +920,9 @@ export function diPublic(def: DirectiveDef<any>): void {
  * @param self
  * @param method
  */
-export function lifecycle(
-  lifeCycle: LifecycleHook.ON_DESTROY, self: any, method: Function): void;
+export function lifecycle(lifeCycle: LifecycleHook.ON_DESTROY, self: any, method: Function): void;
 export function lifecycle(lifeCycle: LifecycleHook): boolean;
-export function lifecycle(
-  lifeCycle: LifecycleHook, self?: any, method?: Function): boolean {
+export function lifecycle(lifeCycle: LifecycleHook, self?: any, method?: Function): boolean {
   if (lifeCycle === LifecycleHook.ON_INIT) {
     return creationMode;
   } else if (lifeCycle === LifecycleHook.ON_DESTROY) {
@@ -1195,8 +1193,7 @@ export function projectionDef(selectors?: CssSelector[]): LNode[][] {
  * @param {number} localIndex - index under which distribution of projected nodes was memorized
  * @param {number} selectorIndex - 0 means <ng-content> without any selector
  */
-export function projection(
-    nodeIndex: number, localIndex: number, selectorIndex: number = 0): void {
+export function projection(nodeIndex: number, localIndex: number, selectorIndex: number = 0): void {
   const projectedNodes: ProjectionState = [];
   const node = createLNode(nodeIndex, LNodeFlags.Projection, null, projectedNodes);
   isParent = false;  // self closing

--- a/packages/core/src/render3/l_node_static.ts
+++ b/packages/core/src/render3/l_node_static.ts
@@ -39,6 +39,11 @@ export interface LNodeStatic {
   attrs: string[]|null;
 
   /**
+   * A local name under which a given element is exported in a view.
+   */
+  localName: string|null;
+
+  /**
    * This property contains information about input properties that
    * need to be set once from attribute data.
    */

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -10,7 +10,8 @@ import {assertNotNull} from './assert';
 import {ContainerState, ProjectionState, ViewOrContainerState, ViewState} from './interfaces';
 import {LContainer, LElement, LNode, LNodeFlags, LProjection, LText, LView} from './l_node';
 import {assertNodeType} from './node_assert';
-import {RComment, RElement, RNode, RText, ProceduralRenderer3} from './renderer';
+import {ProceduralRenderer3, RComment, RElement, RNode, RText} from './renderer';
+
 
 /**
  * Finds the closest DOM node above a given container in the hierarchy.
@@ -93,26 +94,27 @@ export function addRemoveViewFromContainer(
       const renderer = container.view.renderer;
       const isFnRenderer = (renderer as ProceduralRenderer3).listen;
       if (type === LNodeFlags.Element) {
-        insertMode ?
-            (isFnRenderer ?
-                 (renderer as ProceduralRenderer3)
-                     .insertBefore !(parent, node.native !, beforeNode as RNode | null) :
-                 parent.insertBefore(node.native !, beforeNode as RNode | null, true)) :
-            (isFnRenderer ?
-                 (renderer as ProceduralRenderer3).removeChild !(parent as RElement, node.native !) :
-                 parent.removeChild(node.native !));
+        insertMode ? (isFnRenderer ?
+                          (renderer as ProceduralRenderer3)
+                              .insertBefore !(parent, node.native !, beforeNode as RNode | null) :
+                          parent.insertBefore(node.native !, beforeNode as RNode | null, true)) :
+                     (isFnRenderer ?
+                          (renderer as ProceduralRenderer3)
+                              .removeChild !(parent as RElement, node.native !) :
+                          parent.removeChild(node.native !));
         nextNode = node.next;
       } else if (type === LNodeFlags.Container) {
         // if we get to a container, it must be a root node of a view because we are only
         // propagating down into child views / containers and not child elements
         const childContainerData: ContainerState = (node as LContainer).data;
-        insertMode ?
-            (isFnRenderer ?
-                 (renderer as ProceduralRenderer3).appendChild !(parent as RElement, node.native !) :
-                 parent.appendChild(node.native !)) :
-            (isFnRenderer ?
-                 (renderer as ProceduralRenderer3).removeChild !(parent as RElement, node.native !) :
-                 parent.removeChild(node.native !));
+        insertMode ? (isFnRenderer ?
+                          (renderer as ProceduralRenderer3)
+                              .appendChild !(parent as RElement, node.native !) :
+                          parent.appendChild(node.native !)) :
+                     (isFnRenderer ?
+                          (renderer as ProceduralRenderer3)
+                              .removeChild !(parent as RElement, node.native !) :
+                          parent.removeChild(node.native !));
         nextNode = childContainerData.views.length ? childContainerData.views[0].child : null;
       } else if (type === LNodeFlags.Projection) {
         nextNode = (node as LProjection).data[0];
@@ -374,7 +376,8 @@ export function insertChild(node: LNode, currentView: ViewState): void {
     }
     const renderer = currentView.renderer;
     (renderer as ProceduralRenderer3).listen ?
-        (renderer as ProceduralRenderer3).insertBefore !(parent.native !, node.native !, nativeSibling) :
+        (renderer as ProceduralRenderer3)
+            .insertBefore !(parent.native !, node.native !, nativeSibling) :
         parent.native !.insertBefore(node.native !, nativeSibling, false);
   }
 }

--- a/packages/core/src/render3/public_interfaces.ts
+++ b/packages/core/src/render3/public_interfaces.ts
@@ -7,7 +7,9 @@
  */
 
 import {Type} from '../core';
-import {diPublic, componentRefresh} from './instructions';
+
+import {componentRefresh, diPublic} from './instructions';
+
 
 
 /**

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, T, V, c, defineComponent, e, cR, cr, v} from '../../src/render3/index';
+import {C, E, T, V, c, cR, cr, defineComponent, e, v} from '../../src/render3/index';
 
 import {document, renderComponent} from './render_util';
 

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, P, T, V, c, pD, detectChanges, e, m, cR, cr, v} from '../../src/render3/index';
+import {C, D, E, P, T, V, c, cR, cr, detectChanges, e, m, pD, v} from '../../src/render3/index';
 
 import {createComponent, renderComponent, toHtml} from './render_util';
 

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, T, V, b, c, e, cR, cr, t, v} from '../../src/render3/index';
+import {C, E, T, V, b, c, cR, cr, e, t, v} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -9,7 +9,7 @@
 import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {bloomFindPossibleInjector} from '../../src/render3/di';
-import {C, D, E, PublicFeature, T, V, b, b2, c, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, cR, cr, t, v} from '../../src/render3/index';
+import {C, D, E, PublicFeature, T, V, b, b2, c, cR, cr, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, t, v} from '../../src/render3/index';
 import {bloomAdd, createLNode, createViewState, enterView, getOrCreateNodeInjector, leaveView} from '../../src/render3/instructions';
 import {LNodeFlags, LNodeInjector} from '../../src/render3/l_node';
 

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, T, V, a, b, c, defineComponent, defineDirective, e, k, p, cR, cr, t, v} from '../../src/render3/index';
+import {C, D, E, T, V, a, b, c, cR, cr, defineComponent, defineDirective, e, k, p, t, v} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, NC, T, V, a, b, b1, b2, b3, b4, b5, b6, b7, b8, bV, c, defineComponent, e, k, p, r, cR, cr, s, t, v} from '../../src/render3/index';
+import {C, D, E, NC, T, V, a, b, b1, b2, b3, b4, b5, b6, b7, b8, bV, c, cR, cr, defineComponent, e, k, p, r, s, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, ComponentTemplate, D, E, L, LifecycleHook, T, V, b, c, defineComponent, e, l, p, cR, cr, v} from '../../src/render3/index';
+import {C, ComponentTemplate, D, E, L, LifecycleHook, T, V, b, c, cR, cr, defineComponent, e, l, p, v} from '../../src/render3/index';
+
 import {containerEl, renderToHtml} from './render_util';
 
 describe('lifecycles', () => {

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, L, T, V, c, defineComponent, e, cR, cr, v} from '../../src/render3/index';
+import {C, D, E, L, T, V, c, cR, cr, defineComponent, e, v} from '../../src/render3/index';
+
 import {containerEl, renderComponent, renderToHtml} from './render_util';
 
 

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -14,6 +14,7 @@ function testLStaticData(tagName: string, attrs: string[] | null): LNodeStatic {
   return {
     tagName,
     attrs,
+    localName: null,
     initialInputs: undefined,
     inputs: undefined,
     outputs: undefined,

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, D, E, L, LifecycleHook, T, V, b, c, defineComponent, defineDirective, e, l, p, cR, cr, v} from '../../src/render3/index';
+import {C, D, E, L, LifecycleHook, T, V, b, c, cR, cr, defineComponent, defineDirective, e, l, p, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, D, E, L, T, V, b, b1, c, defineComponent, defineDirective, e, p, cR, cr, t, v} from '../../src/render3/index';
+import {C, D, E, L, T, V, b, b1, c, cR, cr, defineComponent, defineDirective, e, p, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -48,4 +48,69 @@ describe('query', () => {
     expect((parent.query0 as QueryList<any>).toArray()).toEqual([child1]);
     expect((parent.query1 as QueryList<any>).toArray()).toEqual([child1, child2]);
   });
+
+  describe('local names', () => {
+
+    it('should query for a single element', () => {
+
+      let elToQuery;
+      /**
+       * <div #foo></div>
+       * <div></div>
+       * class Cmpt {
+       *  @ViewChildren('foo') query;
+       * }
+       */
+      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+        let tmp: any;
+        if (cm) {
+          m(0, Q(['foo']));
+          elToQuery = E(1, 'div', [], 'foo');
+          e();
+          E(2, 'div');
+          e();
+        }
+        qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+      });
+
+      const cmptInstance = renderComponent(Cmpt);
+      const query = (cmptInstance.query as QueryList<any>);
+      expect(query.length).toBe(1);
+      expect(query.first.nativeElement).toEqual(elToQuery);
+    });
+
+    it('should query for multiple elements', () => {
+
+      let el1ToQuery;
+      let el2ToQuery;
+      /**
+       * <div #foo></div>
+       * <div></div>
+       * <div #bar></div>
+       * class Cmpt {
+       *  @ViewChildren('foo,bar') query;
+       * }
+       */
+      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+        let tmp: any;
+        if (cm) {
+          m(0, Q(['foo', 'bar']));
+          el1ToQuery = E(1, 'div', null, 'foo');
+          e();
+          E(2, 'div');
+          e();
+          el2ToQuery = E(3, 'div', null, 'bar');
+          e();
+        }
+        qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+      });
+
+      const cmptInstance = renderComponent(Cmpt);
+      const query = (cmptInstance.query as QueryList<any>);
+      expect(query.length).toBe(2);
+      expect(query.first.nativeElement).toEqual(el1ToQuery);
+      expect(query.last.nativeElement).toEqual(el2ToQuery);
+    });
+
+  });
 });


### PR DESCRIPTION
This PR adds support for `@ViewChildren` queries for elements with local names (ex. `@ViewChildren('foo')` foos;  should match `<div #foo>`. This is a first, small PR to update data structures as this new functionality requires storage of local names (ex. `#foo`) for a given node. As soon as we got all the necessary data stored the actual querying is very straightforward with the current infrastructure in place - the most important change is in packages/core/src/render3/query.ts

This PR also changes format of selector storage for queries - since in the current Angular we can only query for types or names (one or more) there is no reason to create / support more complex data structures that are prepared for queries by CSS selectors.

For now I'm not getting `ElementRef` from the injector as there are couple of small details I would like to discuss before.