### PR TITLE
docs(core): add docs to instructions, renames

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -9,7 +9,7 @@
 import {ComponentRef, EmbeddedViewRef, Injector} from '../core';
 
 import {assertNotNull} from './assert';
-import {NG_HOST_SYMBOL, createError, createViewState, directiveCreate, elementHost, enterView, leaveView} from './instructions';
+import {NG_HOST_SYMBOL, createError, createViewState, directive, elementHost, enterView, leaveView} from './instructions';
 import {LElement} from './l_node';
 import {ComponentDef, ComponentType} from './public_interfaces';
 import {RElement, Renderer3, RendererFactory3} from './renderer';
@@ -146,7 +146,7 @@ export function renderComponent<T>(
     // Create element node at index 0 in data array
     elementHost(opts.host || componentDef.tag, componentDef);
     // Create directive instance with n() and store at index 1 in data array (el is 0)
-    component = directiveCreate(1, componentDef.n(), componentDef);
+    component = directive(1, componentDef.n(), componentDef);
   } finally {
     leaveView(oldView);
   }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -168,7 +168,8 @@ function bloomHashBit(type: viewEngine.Type<any>): number|null {
 export function bloomFindPossibleInjector(
     startInjector: LNodeInjector, bloomBit: number): LNodeInjector|null {
   // Create a mask that targets the specific bit associated with the directive we're looking for.
-  // This will be a number between 0 and 31, corresponding to a bit position in a 32 bit integer.
+  // JS bit operations are 32 bits, so this will be a number between 2^0 and 2^31, corresponding
+  // to bit positions 0 - 31 in a 32 bit integer.
   const mask = 1 << bloomBit;
 
   // Traverse up the injector tree until we find a potential match or until we know there *isn't* a

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -20,7 +20,7 @@ import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveD
 // - lower case for closing: c(containerEnd), e(elementEnd), v(viewEnd)
 // clang-format off
 export {
-  LifeCycleGuard,
+  LifecycleHook,
 
   NO_CHANGE as NC,
 
@@ -35,33 +35,36 @@ export {
   bind8 as b8,
   bindV as bV,
 
-  containerCreate as C,
-  containerEnd as c,
-  contentProjection as P,
+  componentRefresh as r,
 
-  directiveCreate as D,
-  directiveLifeCycle as l,
-  distributeProjectedNodes as dP,
+  containerStart as C,
+  containerEnd as c,
+  containerRefreshStart as cR,
+  containerRefreshEnd as cr,
+
+  directive as D,
 
   elementAttribute as a,
   elementClass as k,
-  elementCreate as E,
   elementEnd as e,
   elementProperty as p,
+  elementStart as E,
   elementStyle as s,
 
-  listenerCreate as L,
+  lifecycle as l,
+  listener as L,
   memory as m,
-  queryCreate as Q,
 
-  refreshComponent as r,
-  refreshContainer as rC,
-  refreshContainerEnd as rc,
-  refreshQuery as rQ,
-  textCreate as T,
-  textCreateBound as t,
+  projection as P,
+  projectionDef as pD,
 
-  viewCreate as V,
+  query as Q,
+  queryRefresh as qR,
+
+  text as T,
+  textBinding as t,
+
+  viewStart as V,
   viewEnd as v,
 } from './instructions';
 // clang-format on

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -10,7 +10,7 @@ import {assertNotNull} from './assert';
 import {ContainerState, ProjectionState, ViewOrContainerState, ViewState} from './interfaces';
 import {LContainer, LElement, LNode, LNodeFlags, LProjection, LText, LView} from './l_node';
 import {assertNodeType} from './node_assert';
-import {RComment, RElement, RNode, RText, Renderer3Fn} from './renderer';
+import {RComment, RElement, RNode, RText, ProceduralRenderer3} from './renderer';
 
 /**
  * Finds the closest DOM node above a given container in the hierarchy.
@@ -91,15 +91,15 @@ export function addRemoveViewFromContainer(
       const type = node.flags & LNodeFlags.TYPE_MASK;
       let nextNode: LNode|null = null;
       const renderer = container.view.renderer;
-      const isFnRenderer = (renderer as Renderer3Fn).listen;
+      const isFnRenderer = (renderer as ProceduralRenderer3).listen;
       if (type === LNodeFlags.Element) {
         insertMode ?
             (isFnRenderer ?
-                 (renderer as Renderer3Fn)
+                 (renderer as ProceduralRenderer3)
                      .insertBefore !(parent, node.native !, beforeNode as RNode | null) :
                  parent.insertBefore(node.native !, beforeNode as RNode | null, true)) :
             (isFnRenderer ?
-                 (renderer as Renderer3Fn).removeChild !(parent as RElement, node.native !) :
+                 (renderer as ProceduralRenderer3).removeChild !(parent as RElement, node.native !) :
                  parent.removeChild(node.native !));
         nextNode = node.next;
       } else if (type === LNodeFlags.Container) {
@@ -108,10 +108,10 @@ export function addRemoveViewFromContainer(
         const childContainerData: ContainerState = (node as LContainer).data;
         insertMode ?
             (isFnRenderer ?
-                 (renderer as Renderer3Fn).appendChild !(parent as RElement, node.native !) :
+                 (renderer as ProceduralRenderer3).appendChild !(parent as RElement, node.native !) :
                  parent.appendChild(node.native !)) :
             (isFnRenderer ?
-                 (renderer as Renderer3Fn).removeChild !(parent as RElement, node.native !) :
+                 (renderer as ProceduralRenderer3).removeChild !(parent as RElement, node.native !) :
                  parent.removeChild(node.native !));
         nextNode = childContainerData.views.length ? childContainerData.views[0].child : null;
       } else if (type === LNodeFlags.Projection) {
@@ -332,8 +332,8 @@ export function appendChild(parent: LNode, child: RNode | null, currentView: Vie
     // We only add element if not in View or not projected.
 
     const renderer = currentView.renderer;
-    (renderer as Renderer3Fn).listen ?
-        (renderer as Renderer3Fn).appendChild !(parent.native !as RElement, child) :
+    (renderer as ProceduralRenderer3).listen ?
+        (renderer as ProceduralRenderer3).appendChild !(parent.native !as RElement, child) :
         parent.native !.appendChild(child);
     return true;
   }
@@ -373,8 +373,8 @@ export function insertChild(node: LNode, currentView: ViewState): void {
       sibling = sibling.next;
     }
     const renderer = currentView.renderer;
-    (renderer as Renderer3Fn).listen ?
-        (renderer as Renderer3Fn).insertBefore !(parent.native !, node.native !, nativeSibling) :
+    (renderer as ProceduralRenderer3).listen ?
+        (renderer as ProceduralRenderer3).insertBefore !(parent.native !, node.native !, nativeSibling) :
         parent.native !.insertBefore(node.native !, nativeSibling, false);
   }
 }

--- a/packages/core/src/render3/public_interfaces.ts
+++ b/packages/core/src/render3/public_interfaces.ts
@@ -7,7 +7,7 @@
  */
 
 import {Type} from '../core';
-import {diPublic, refreshComponent} from './instructions';
+import {diPublic, componentRefresh} from './instructions';
 
 
 /**
@@ -150,7 +150,7 @@ export function defineComponent<T>(componentDefinition: ComponentDefArgs<T>): Co
     n: componentDefinition.factory,
     tag: (componentDefinition as ComponentDefArgs<T>).tag || null !,
     template: (componentDefinition as ComponentDefArgs<T>).template || null !,
-    r: componentDefinition.refresh || refreshComponent,
+    r: componentDefinition.refresh || componentRefresh,
     inputs: invertObject(componentDefinition.inputs),
     outputs: invertObject(componentDefinition.outputs),
     methods: invertObject(componentDefinition.methods),

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -209,6 +209,6 @@ class QueryList_<T>/* implements viewEngine.QueryList<T> */ {
 export type QueryList<T> = viewEngine.QueryList<T>;
 export const QueryList: typeof viewEngine.QueryList = QueryList_ as any;
 
-export function refreshQuery(query: QueryList<any>): boolean {
+export function queryRefresh(query: QueryList<any>): boolean {
   return (query as any as QueryList_<any>)._refresh();
 }

--- a/packages/core/src/render3/renderer.ts
+++ b/packages/core/src/render3/renderer.ts
@@ -24,12 +24,10 @@ export enum RendererStyleFlags3 {
   DashCase = 1 << 1
 }
 
-export type Renderer3 = Renderer3oo | Renderer3Fn;
+export type Renderer3 = ObjectOrientedRenderer3 | ProceduralRenderer3;
 
-/**
- * Object Oriented style of API needed to create elements and text nodes.
- */
-export interface Renderer3oo {
+/** Object Oriented style of API needed to create elements and text nodes. */
+export interface ObjectOrientedRenderer3 {
   createComment(data: string): RComment;
   createElement(tagName: string): RElement;
   createTextNode(data: string): RText;
@@ -37,10 +35,8 @@ export interface Renderer3oo {
   querySelector(selectors: string): RElement|null;
 }
 
-/**
- * Functional style of API needed to create elements and text nodes.
- */
-export interface Renderer3Fn {
+/** Procedural style of API needed to create elements and text nodes. */
+export interface ProceduralRenderer3 {
   destroy(): void;
   createElement(name: string, namespace?: string|null): RElement;
   createComment(value: string): RComment;
@@ -77,9 +73,7 @@ export interface RendererFactory3 {
   end?(): void;
 }
 
-/**
- * Subset of API needed for appending elements and text nodes.
- */
+/** Subset of API needed for appending elements and text nodes. */
 export interface RNode {
   removeChild(oldChild: RNode): void;
 

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, T, V, c, defineComponent, e, rC, rc, v} from '../../src/render3/index';
+import {C, E, T, V, c, defineComponent, e, cR, cr, v} from '../../src/render3/index';
 
 import {document, renderComponent} from './render_util';
 
@@ -39,7 +39,7 @@ describe('iv perf test', () => {
                 C(0);
                 c();
               }
-              rC(0);
+              cR(0);
               {
                 for (let i = 0; i < count; i++) {
                   let cm0 = V(0);
@@ -53,7 +53,7 @@ describe('iv perf test', () => {
                   v();
                 }
               }
-              rc();
+              cr();
             },
             factory: () => new Component
           });

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, P, T, V, c, dP, detectChanges, e, m, rC, rc, v} from '../../src/render3/index';
+import {C, D, E, P, T, V, c, pD, detectChanges, e, m, cR, cr, v} from '../../src/render3/index';
 
 import {createComponent, renderComponent, toHtml} from './render_util';
 
@@ -18,7 +18,7 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         E(1, 'div');
         { P(2, 0); }
         e();
@@ -46,7 +46,7 @@ describe('content projection', () => {
   it('should project content when root.', () => {
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         P(1, 0);
       }
     });
@@ -68,7 +68,7 @@ describe('content projection', () => {
   it('should re-project content when root.', () => {
     const GrandChild = createComponent('grand-child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         E(1, 'div');
         { P(2, 0); }
         e();
@@ -76,7 +76,7 @@ describe('content projection', () => {
     });
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         E(1, GrandChild.ngComponentDef);
         {
           D(2, GrandChild.ngComponentDef.n(), GrandChild.ngComponentDef);
@@ -108,7 +108,7 @@ describe('content projection', () => {
   it('should project content with container.', () => {
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         E(1, 'div');
         { P(2, 0); }
         e();
@@ -126,7 +126,7 @@ describe('content projection', () => {
         }
         e();
       }
-      rC(3);
+      cR(3);
       {
         if (ctx.value) {
           if (V(0)) {
@@ -135,7 +135,7 @@ describe('content projection', () => {
           v();
         }
       }
-      rc();
+      cr();
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -151,7 +151,7 @@ describe('content projection', () => {
   it('should project content with container into root', () => {
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         P(1, 0);
       }
     });
@@ -165,7 +165,7 @@ describe('content projection', () => {
         }
         e();
       }
-      rC(2);
+      cR(2);
       {
         if (ctx.value) {
           if (V(0)) {
@@ -174,7 +174,7 @@ describe('content projection', () => {
           v();
         }
       }
-      rc();
+      cr();
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -192,7 +192,7 @@ describe('content projection', () => {
   it('should project content with container and if-else.', () => {
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         E(1, 'div');
         { P(2, 0); }
         e();
@@ -210,7 +210,7 @@ describe('content projection', () => {
         }
         e();
       }
-      rC(3);
+      cR(3);
       {
         if (ctx.value) {
           if (V(0)) {
@@ -224,7 +224,7 @@ describe('content projection', () => {
           v();
         }
       }
-      rc();
+      cr();
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -251,7 +251,7 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         E(1, 'div');
         {
           C(2);
@@ -259,7 +259,7 @@ describe('content projection', () => {
         }
         e();
       }
-      rC(2);
+      cR(2);
       {
         if (!ctx.skipContent) {
           if (V(0)) {
@@ -270,7 +270,7 @@ describe('content projection', () => {
           v();
         }
       }
-      rc();
+      cr();
     });
 
     /**
@@ -308,7 +308,7 @@ describe('content projection', () => {
         */
        const Child = createComponent('child', function(ctx: any, cm: boolean) {
          if (cm) {
-           m(0, dP());
+           m(0, pD());
            E(1, 'div');
            {
              C(2);
@@ -316,7 +316,7 @@ describe('content projection', () => {
            }
            e();
          }
-         rC(2);
+         cR(2);
          {
            if (!ctx.skipContent) {
              if (V(0)) {
@@ -325,7 +325,7 @@ describe('content projection', () => {
              v();
            }
          }
-         rc();
+         cr();
        });
 
        /**
@@ -357,7 +357,7 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         E(1, 'div');
         { P(2, 0); }
         e();
@@ -406,7 +406,7 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, dP());
+        m(0, pD());
         P(1, 0);
         E(2, 'div');
         {
@@ -415,7 +415,7 @@ describe('content projection', () => {
         }
         e();
       }
-      rC(3);
+      cR(3);
       {
         if (ctx.show) {
           if (V(0)) {
@@ -424,7 +424,7 @@ describe('content projection', () => {
           v();
         }
       }
-      rc();
+      cr();
     });
 
     /**
@@ -459,7 +459,7 @@ describe('content projection', () => {
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
           m(0,
-            dP([[[['span', 'title', 'toFirst'], null]], [[['span', 'title', 'toSecond'], null]]]));
+            pD([[[['span', 'title', 'toFirst'], null]], [[['span', 'title', 'toSecond'], null]]]));
           E(1, 'div', ['id', 'first']);
           { P(2, 0, 1); }
           e();
@@ -506,7 +506,7 @@ describe('content projection', () => {
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
           m(0,
-            dP([[[['span', 'class', 'toFirst'], null]], [[['span', 'class', 'toSecond'], null]]]));
+            pD([[[['span', 'class', 'toFirst'], null]], [[['span', 'class', 'toSecond'], null]]]));
           E(1, 'div', ['id', 'first']);
           { P(2, 0, 1); }
           e();
@@ -553,7 +553,7 @@ describe('content projection', () => {
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
           m(0,
-            dP([[[['span', 'class', 'toFirst'], null]], [[['span', 'class', 'toSecond'], null]]]));
+            pD([[[['span', 'class', 'toFirst'], null]], [[['span', 'class', 'toSecond'], null]]]));
           E(1, 'div', ['id', 'first']);
           { P(2, 0, 1); }
           e();
@@ -599,7 +599,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
-          m(0, dP([[[['span'], null]], [[['span', 'class', 'toSecond'], null]]]));
+          m(0, pD([[[['span'], null]], [[['span', 'class', 'toSecond'], null]]]));
           E(1, 'div', ['id', 'first']);
           { P(2, 0, 1); }
           e();
@@ -645,7 +645,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
-          m(0, dP([[[['span', 'class', 'toFirst'], null]]]));
+          m(0, pD([[[['span', 'class', 'toFirst'], null]]]));
           E(1, 'div', ['id', 'first']);
           { P(2, 0, 1); }
           e();
@@ -692,7 +692,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
-          m(0, dP([[[['span', 'class', 'toSecond'], null]]]));
+          m(0, pD([[[['span', 'class', 'toSecond'], null]]]));
           E(1, 'div', ['id', 'first']);
           { P(2, 0); }
           e();
@@ -746,7 +746,7 @@ describe('content projection', () => {
        */
       const GrandChild = createComponent('grand-child', function(ctx: any, cm: boolean) {
         if (cm) {
-          m(0, dP([[[['span'], null]]]));
+          m(0, pD([[[['span'], null]]]));
           P(1, 0, 1);
           E(2, 'hr');
           e();
@@ -762,7 +762,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
-          m(0, dP());
+          m(0, pD());
           E(1, GrandChild.ngComponentDef);
           {
             D(2, GrandChild.ngComponentDef.n(), GrandChild.ngComponentDef);
@@ -812,7 +812,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
-          m(0, dP([[[['div'], null]]]));
+          m(0, pD([[[['div'], null]]]));
           E(1, 'span');
           { P(2, 0, 1); }
           e();
@@ -834,7 +834,7 @@ describe('content projection', () => {
           }
           e();
         }
-        rC(2);
+        cR(2);
         {
           if (true) {
             if (V(0)) {
@@ -845,7 +845,7 @@ describe('content projection', () => {
             v();
           }
         }
-        rc();
+        cr();
         Child.ngComponentDef.r(1, 0);
       });
       const parent = renderComponent(Parent);

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, T, V, b, c, e, rC, rc, t, v} from '../../src/render3/index';
+import {C, E, T, V, b, c, e, cR, cr, t, v} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 
@@ -23,7 +23,7 @@ describe('JS control flow', () => {
         }
         e();
       }
-      rC(1);
+      cR(1);
       {
         if (ctx.condition) {
           let cm1 = V(1);
@@ -38,7 +38,7 @@ describe('JS control flow', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     expect(renderToHtml(Template, ctx)).toEqual('<div><span>Hello</span></div>');
@@ -74,7 +74,7 @@ describe('JS control flow', () => {
         }
         e();
       }
-      rC(1);
+      cR(1);
       {
         if (ctx.condition) {
           let cm1 = V(1);
@@ -87,7 +87,7 @@ describe('JS control flow', () => {
               }
               e();
             }
-            rC(1);
+            cR(1);
             {
               if (ctx.condition2) {
                 let cm2 = V(2);
@@ -99,12 +99,12 @@ describe('JS control flow', () => {
                 v();
               }
             }
-            rc();
+            cr();
           }
           v();
         }
       }
-      rc();
+      cr();
     }
 
     expect(renderToHtml(Template, ctx)).toEqual('<div><span>Hello</span></div>');
@@ -143,7 +143,7 @@ describe('JS control flow', () => {
         C(2);
         c();
       }
-      rC(2);
+      cR(2);
       {
         if (ctx.condition1) {
           let cm0 = V(0);
@@ -152,7 +152,7 @@ describe('JS control flow', () => {
               C(0);
               c();
             }
-            rC(0);
+            cR(0);
             {
               if (ctx.condition2) {
                 let cm0 = V(0);
@@ -164,12 +164,12 @@ describe('JS control flow', () => {
                 v();
               }
             }
-            rc();
+            cr();
           }
           v();
         }
       }
-      rc();
+      cr();
     }
 
     expect(renderToHtml(Template, {condition1: true, condition2: true}))
@@ -191,7 +191,7 @@ describe('JS control flow', () => {
         }
         e();
       }
-      rC(1);
+      cR(1);
       {
         for (let i = 0; i < ctx.data.length; i++) {
           let cm1 = V(1);
@@ -206,7 +206,7 @@ describe('JS control flow', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     expect(renderToHtml(Template, ctx)).toEqual('<ul><li>a</li><li>b</li><li>c</li></ul>');
@@ -240,7 +240,7 @@ describe('JS control flow', () => {
         }
         e();
       }
-      rC(1);
+      cR(1);
       {
         for (let i = 0; i < ctx.data[0].length; i++) {
           let cm1 = V(1);
@@ -253,7 +253,7 @@ describe('JS control flow', () => {
               }
               e();
             }
-            rC(1);
+            cR(1);
             {
               ctx.data[1].forEach((value: string, ind: number) => {
                 if (V(2)) {
@@ -263,12 +263,12 @@ describe('JS control flow', () => {
                 v();
               });
             }
-            rc();
+            cr();
           }
           v();
         }
       }
-      rc();
+      cr();
     }
 
     expect(renderToHtml(Template, ctx)).toEqual('<ul><li>aman</li><li>bmbn</li><li>cmcn</li></ul>');
@@ -303,7 +303,7 @@ describe('JS control flow', () => {
         }
         e();
       }
-      rC(2);
+      cR(2);
       {
         for (let i = 0; i < ctx.cafes.length; i++) {
           let cm1 = V(1);
@@ -317,7 +317,7 @@ describe('JS control flow', () => {
               T(3, '-');
             }
             t(1, b(ctx.cafes[i].name));
-            rC(2);
+            cR(2);
             {
               for (let j = 0; j < ctx.cafes[i].entrees.length; j++) {
                 if (V(1)) {
@@ -327,12 +327,12 @@ describe('JS control flow', () => {
                 v();
               }
             }
-            rc();
+            cr();
           }
           v();
         }
       }
-      rc();
+      cr();
     }
 
     const ctx = {
@@ -385,7 +385,7 @@ describe('JS control flow', () => {
         }
         e();
       }
-      rC(2);
+      cR(2);
       {
         for (let i = 0; i < ctx.cafes.length; i++) {
           let cm1 = V(1);
@@ -399,7 +399,7 @@ describe('JS control flow', () => {
               T(3, '-');
             }
             t(1, b(ctx.cafes[i].name));
-            rC(2);
+            cR(2);
             {
               for (let j = 0; j < ctx.cafes[i].entrees.length; j++) {
                 let cm1 = V(1);
@@ -412,7 +412,7 @@ describe('JS control flow', () => {
                     c();
                   }
                   t(1, b(ctx.cafes[i].entrees[j].name));
-                  rC(2);
+                  cR(2);
                   {
                     for (let k = 0; k < ctx.cafes[i].entrees[j].foods.length; k++) {
                       if (V(1)) {
@@ -422,17 +422,17 @@ describe('JS control flow', () => {
                       v();
                     }
                   }
-                  rc();
+                  cr();
                 }
                 v();
               }
             }
-            rc();
+            cr();
           }
           v();
         }
       }
-      rc();
+      cr();
     }
 
     const ctx = {
@@ -476,7 +476,7 @@ describe('JS control flow', () => {
         }
         e();
       }
-      rC(1);
+      cR(1);
       {
         if (ctx.condition) {
           let cm1 = V(1);
@@ -500,7 +500,7 @@ describe('JS control flow', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     expect(renderToHtml(Template, ctx)).toEqual('<div><span>Hello</span></div>');
@@ -527,7 +527,7 @@ describe('JS for loop', () => {
         }
         e();
       }
-      rC(1);
+      cR(1);
       {
         for (let i = 0; i < ctx.data1.length; i++) {
           if (V(1)) {
@@ -544,7 +544,7 @@ describe('JS for loop', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     expect(renderToHtml(Template, ctx)).toEqual('<div>abc12</div>');
@@ -587,20 +587,20 @@ describe('function calls', () => {
         }
         e();
       }
-      rC(2);
+      cR(2);
       {
         let cm0 = V(0);
         { spanify({message: ctx.data[0]}, cm0); }
         v();
       }
-      rc();
-      rC(3);
+      cr();
+      cR(3);
       {
         let cm0 = V(0);
         { spanify({message: ctx.data[1]}, cm0); }
         v();
       }
-      rc();
+      cr();
     }
 
     expect(renderToHtml(Template, ctx))

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -9,7 +9,7 @@
 import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {bloomFindPossibleInjector} from '../../src/render3/di';
-import {C, D, E, PublicFeature, T, V, b, b2, c, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, rC, rc, t, v} from '../../src/render3/index';
+import {C, D, E, PublicFeature, T, V, b, b2, c, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, cR, cr, t, v} from '../../src/render3/index';
 import {bloomAdd, createLNode, createViewState, enterView, getOrCreateNodeInjector, leaveView} from '../../src/render3/instructions';
 import {LNodeFlags, LNodeInjector} from '../../src/render3/l_node';
 
@@ -291,7 +291,7 @@ describe('di', () => {
           }
           e();
         }
-        rC(2);
+        cR(2);
         {
           if (V(0)) {
             E(0, 'span');
@@ -305,7 +305,7 @@ describe('di', () => {
           t(3, b2('', D<ChildDirective>(1).value, '-', D<Child2Directive>(2).value, ''));
           v();
         }
-        rc();
+        cr();
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div><span>ParentDirective-true</span></div>');

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, T, V, a, b, c, defineComponent, defineDirective, e, k, p, rC, rc, t, v} from '../../src/render3/index';
+import {C, D, E, T, V, a, b, c, defineComponent, defineDirective, e, k, p, cR, cr, t, v} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 
@@ -267,7 +267,7 @@ describe('exports', () => {
           }
           e();
         }
-        rC(1);
+        cR(1);
         {
           if (ctx.condition) {
             let cm1 = V(1);
@@ -283,7 +283,7 @@ describe('exports', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       expect(renderToHtml(Template, {

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, NC, T, V, a, b, b1, b2, b3, b4, b5, b6, b7, b8, bV, c, defineComponent, e, k, p, r, rC, rc, s, t, v} from '../../src/render3/index';
+import {C, D, E, NC, T, V, a, b, b1, b2, b3, b4, b5, b6, b7, b8, bV, c, defineComponent, e, k, p, r, cR, cr, s, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';
@@ -363,7 +363,7 @@ describe('iv integration test', () => {
               C(0);
               c();
             }
-            rC(0);
+            cR(0);
             {
               if (ctx.condition) {
                 if (V(0)) {
@@ -374,7 +374,7 @@ describe('iv integration test', () => {
                 v();
               }
             }
-            rc();
+            cr();
           },
           factory: () => new MyComp,
           inputs: {condition: 'condition'}
@@ -487,7 +487,7 @@ describe('iv integration test', () => {
             e();
           }
           a(0, 'title', b(ctx.title));
-          rC(1);
+          cR(1);
           {
             if (true) {
               let cm1 = V(1);
@@ -502,7 +502,7 @@ describe('iv integration test', () => {
               v();
             }
           }
-          rc();
+          cr();
         }
 
         // initial binding
@@ -602,7 +602,7 @@ describe('iv integration test', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -613,7 +613,7 @@ describe('iv integration test', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       expect((Template as any).ngStaticData).toBeUndefined();

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, ComponentTemplate, D, E, L, LifeCycleGuard, T, V, b, c, defineComponent, e, l, p, rC, rc, v} from '../../src/render3/index';
+import {C, ComponentTemplate, D, E, L, LifecycleHook, T, V, b, c, defineComponent, e, l, p, cR, cr, v} from '../../src/render3/index';
 import {containerEl, renderToHtml} from './render_util';
 
 describe('lifecycles', () => {
@@ -36,7 +36,7 @@ describe('lifecycles', () => {
           tag: name,
           factory: () => {
             const comp = new Component();
-            l(LifeCycleGuard.ON_DESTROY, comp, comp.ngOnDestroy);
+            l(LifecycleHook.ON_DESTROY, comp, comp.ngOnDestroy);
             return comp;
           },
           inputs: {val: 'val'},
@@ -57,7 +57,7 @@ describe('lifecycles', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -69,7 +69,7 @@ describe('lifecycles', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       renderToHtml(Template, {condition: true});
@@ -90,7 +90,7 @@ describe('lifecycles', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -108,7 +108,7 @@ describe('lifecycles', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       renderToHtml(Template, {condition: true});
@@ -130,7 +130,7 @@ describe('lifecycles', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -142,7 +142,7 @@ describe('lifecycles', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       renderToHtml(Template, {condition: true});
@@ -174,7 +174,7 @@ describe('lifecycles', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -186,7 +186,7 @@ describe('lifecycles', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       renderToHtml(Template, {condition: true});
@@ -211,7 +211,7 @@ describe('lifecycles', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -226,7 +226,7 @@ describe('lifecycles', () => {
             }
             p(0, 'val', b('1'));
             Comp.ngComponentDef.r(1, 0);
-            rC(2);
+            cR(2);
             {
               if (ctx.condition2) {
                 if (V(0)) {
@@ -239,13 +239,13 @@ describe('lifecycles', () => {
                 v();
               }
             }
-            rc();
+            cr();
             p(3, 'val', b('3'));
             Comp.ngComponentDef.r(4, 3);
             v();
           }
         }
-        rc();
+        cr();
       }
 
       renderToHtml(Template, {condition: true, condition2: true});
@@ -289,7 +289,7 @@ describe('lifecycles', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -304,7 +304,7 @@ describe('lifecycles', () => {
             }
             p(0, 'val', b('1'));
             Comp.ngComponentDef.r(1, 0);
-            rC(2);
+            cR(2);
             {
               for (let j = 2; j < ctx.len; j++) {
                 if (V(0)) {
@@ -317,13 +317,13 @@ describe('lifecycles', () => {
                 v();
               }
             }
-            rc();
+            cr();
             p(3, 'val', b('5'));
             Comp.ngComponentDef.r(4, 3);
             v();
           }
         }
-        rc();
+        cr();
       }
 
       /**
@@ -369,7 +369,7 @@ describe('lifecycles', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -393,7 +393,7 @@ describe('lifecycles', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       class App {

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, L, T, V, c, defineComponent, e, rC, rc, v} from '../../src/render3/index';
+import {C, D, E, L, T, V, c, defineComponent, e, cR, cr, v} from '../../src/render3/index';
 import {containerEl, renderComponent, renderToHtml} from './render_util';
 
 
@@ -89,7 +89,7 @@ describe('event listeners', () => {
       if (cm) {
         C(0);
       }
-      rC(0);
+      cR(0);
       {
         if (ctx.showing) {
           if (V(1)) {
@@ -103,7 +103,7 @@ describe('event listeners', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     let comp = new MyComp();
@@ -138,7 +138,7 @@ describe('event listeners', () => {
         C(0);
         c();
       }
-      rC(0);
+      cR(0);
       {
         if (ctx.showing) {
           if (V(0)) {
@@ -146,7 +146,7 @@ describe('event listeners', () => {
             C(1);
             c();
           }
-          rC(1);
+          cR(1);
           {
             if (ctx.button) {
               if (V(0)) {
@@ -160,11 +160,11 @@ describe('event listeners', () => {
               v();
             }
           }
-          rc();
+          cr();
           v();
         }
       }
-      rc();
+      cr();
     }
 
     const comp = {showing: true, counter: 0, button: true, onClick: function() { this.counter++; }};
@@ -198,7 +198,7 @@ describe('event listeners', () => {
         C(0);
         c();
       }
-      rC(0);
+      cR(0);
       {
         if (ctx.showing) {
           if (V(0)) {
@@ -215,7 +215,7 @@ describe('event listeners', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     const ctx = {showing: true};
@@ -255,7 +255,7 @@ describe('event listeners', () => {
         C(0);
         c();
       }
-      rC(0);
+      cR(0);
       {
         if (ctx.condition) {
           if (V(0)) {
@@ -265,7 +265,7 @@ describe('event listeners', () => {
             C(2);
             c();
           }
-          rC(1);
+          cR(1);
           {
             if (ctx.sub1) {
               if (V(0)) {
@@ -279,8 +279,8 @@ describe('event listeners', () => {
               v();
             }
           }
-          rc();
-          rC(2);
+          cr();
+          cR(2);
           {
             if (ctx.sub2) {
               if (V(0)) {
@@ -294,11 +294,11 @@ describe('event listeners', () => {
               v();
             }
           }
-          rc();
+          cr();
           v();
         }
       }
-      rc();
+      cr();
     }
 
     const ctx = {condition: true, counter1: 0, counter2: 0, sub1: true, sub2: true};

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, D, E, L, LifeCycleGuard, T, V, b, c, defineComponent, defineDirective, e, l, p, rC, rc, v} from '../../src/render3/index';
+import {C, D, E, L, LifecycleHook, T, V, b, c, defineComponent, defineDirective, e, l, p, cR, cr, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -129,7 +129,7 @@ describe('outputs', () => {
         C(0);
         c();
       }
-      rC(0);
+      cR(0);
       {
         if (ctx.condition) {
           if (V(0)) {
@@ -144,7 +144,7 @@ describe('outputs', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     let counter = 0;
@@ -176,14 +176,14 @@ describe('outputs', () => {
         C(0);
         c();
       }
-      rC(0);
+      cR(0);
       {
         if (ctx.condition) {
           if (V(0)) {
             C(0);
             c();
           }
-          rC(0);
+          cR(0);
           {
             if (ctx.condition2) {
               if (V(0)) {
@@ -198,11 +198,11 @@ describe('outputs', () => {
               v();
             }
           }
-          rc();
+          cr();
           v();
         }
       }
-      rc();
+      cr();
     }
 
     let counter = 0;
@@ -232,7 +232,7 @@ describe('outputs', () => {
         template: function(ctx: any, cm: boolean) {},
         factory: () => {
           destroyComp = new DestroyComp();
-          l(LifeCycleGuard.ON_DESTROY, destroyComp, destroyComp.ngOnDestroy);
+          l(LifecycleHook.ON_DESTROY, destroyComp, destroyComp.ngOnDestroy);
           return destroyComp;
         }
       });
@@ -250,7 +250,7 @@ describe('outputs', () => {
         C(0);
         c();
       }
-      rC(0);
+      cR(0);
       {
         if (ctx.condition) {
           if (V(0)) {
@@ -275,7 +275,7 @@ describe('outputs', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     let clickCounter = 0;
@@ -420,7 +420,7 @@ describe('outputs', () => {
         C(2);
         c();
       }
-      rC(2);
+      cR(2);
       {
         if (ctx.condition) {
           if (V(0)) {
@@ -445,7 +445,7 @@ describe('outputs', () => {
           v();
         }
       }
-      rc();
+      cr();
     }
 
     let counter = 0;

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, D, E, L, T, V, b, b1, c, defineComponent, defineDirective, e, p, rC, rc, t, v} from '../../src/render3/index';
+import {C, D, E, L, T, V, b, b1, c, defineComponent, defineDirective, e, p, cR, cr, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';
@@ -270,7 +270,7 @@ describe('elementProperty', () => {
           c();
         }
         p(0, 'id', b(ctx.id1));
-        rC(3);
+        cR(3);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -293,7 +293,7 @@ describe('elementProperty', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       expect(renderToHtml(Template, {condition: true, id1: 'one', id2: 'two', id3: 'three'}))
@@ -467,7 +467,7 @@ describe('elementProperty', () => {
           C(2);
           c();
         }
-        rC(2);
+        cR(2);
         {
           if (ctx.condition) {
             if (V(0)) {
@@ -485,7 +485,7 @@ describe('elementProperty', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       expect(renderToHtml(Template, {
@@ -530,7 +530,7 @@ describe('elementProperty', () => {
           C(0);
           c();
         }
-        rC(0);
+        cR(0);
         {
           for (let i = 0; i < 2; i++) {
             if (V(0)) {
@@ -542,7 +542,7 @@ describe('elementProperty', () => {
             v();
           }
         }
-        rc();
+        cr();
       }
 
       expect(renderToHtml(Template, {}))

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {D, E, Q, QueryList, e, m, rQ} from '../../src/render3/index';
+import {D, E, Q, QueryList, e, m, qR} from '../../src/render3/index';
 
 import {createComponent, renderComponent} from './render_util';
 
@@ -40,8 +40,8 @@ describe('query', () => {
         }
         e();
       }
-      rQ(tmp = m<QueryList<any>>(0)) && (ctx.query0 = tmp as QueryList<any>);
-      rQ(tmp = m<QueryList<any>>(1)) && (ctx.query1 = tmp as QueryList<any>);
+      qR(tmp = m<QueryList<any>>(0)) && (ctx.query0 = tmp as QueryList<any>);
+      qR(tmp = m<QueryList<any>>(1)) && (ctx.query1 = tmp as QueryList<any>);
     });
 
     const parent = renderComponent(Cmp);


### PR DESCRIPTION
Adds missing docs to `instructions.ts` and renames instructions.  Addresses some of @jelbourn's feedback on https://github.com/angular/angular/pull/20855.