### PR TITLE
refactor: remove import circular dependencies

### DIFF
--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -7,7 +7,6 @@
  */
 
 import {createComponentRef, detectChanges, getHostElement, markDirty, renderComponent} from './component';
-import {inject, injectElementRef, injectTemplateRef, injectViewContainerRef} from './di';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, NgOnChangesFeature, PublicFeature, defineComponent, defineDirective} from './public_interfaces';
 
 // Naming scheme:
@@ -20,6 +19,8 @@ import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveD
 // - lower case for closing: c(containerEnd), e(elementEnd), v(viewEnd)
 // clang-format off
 export {
+  inject, injectElementRef, injectTemplateRef, injectViewContainerRef,
+
   LifecycleHook,
 
   NO_CHANGE as NC,
@@ -69,7 +70,6 @@ export {
 } from './instructions';
 // clang-format on
 export {QueryList} from './query';
-export {inject, injectElementRef, injectTemplateRef, injectViewContainerRef};
 export {
   ComponentDef,
   ComponentTemplate,

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -11,7 +11,7 @@ import {Observable} from 'rxjs/Observable';
 import * as viewEngine from '../core';
 
 import {assertNotNull} from './assert';
-import {injectElementRefForNode} from './di';
+import {getOrCreateElementRef, getOrCreateNodeInjectorForNode} from './di';
 import {QueryState} from './interfaces';
 import {LContainer, LElement, LNode, LNodeFlags, LView} from './l_node';
 import {DirectiveDef} from './public_interfaces';
@@ -117,7 +117,8 @@ function add(predicate: QueryPredicate<any>| null, node: LNode) {
         const selector = predicate.selector !;
         for (let i = 0; i < selector.length; i++) {
           if (selector[i] === staticData.localName) {
-            predicate.values.push(injectElementRefForNode(node as LElement | LContainer));
+            predicate.values.push(getOrCreateElementRef(
+                getOrCreateNodeInjectorForNode(node as LElement | LContainer)));
           }
         }
       }

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -8,9 +8,9 @@
 
 import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
-import {bloomFindPossibleInjector} from '../../src/render3/di';
+import {bloomAdd, bloomFindPossibleInjector} from '../../src/render3/di';
 import {C, D, E, PublicFeature, T, V, b, b2, c, cR, cr, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, t, v} from '../../src/render3/index';
-import {bloomAdd, createLNode, createViewState, enterView, getOrCreateNodeInjector, leaveView} from '../../src/render3/instructions';
+import {createLNode, createViewState, enterView, getOrCreateNodeInjector, leaveView} from '../../src/render3/instructions';
 import {LNodeFlags, LNodeInjector} from '../../src/render3/l_node';
 
 import {renderToHtml} from './render_util';


### PR DESCRIPTION
This PR fixes a circular dependency among those files in Renderer3:
`query` -> `di` -> `instructions` -> `query` -> ...

Looking at the above dependencies the `di` -> `instructions` import is
a problematic one. Previously `di` had an import from `instructions`
since we can known about "current node" only in `instructions`
(and we need "current node" to create node injector instances).

This commit refactors the code in the way that functions in the
`di` file don't depend on any info stored module-global variables
in `instructions`.
