### PR TITLE
feat(core): support 'read' option for ngIvy queries

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -11,8 +11,10 @@
 import * as viewEngine from '../core';
 
 import {LContainer, LElement, LNodeFlags, LNodeInjector} from './l_node';
+import {assertNodeType} from './node_assert';
 import {ComponentTemplate, DirectiveDef} from './public_interfaces';
 import {notImplemented, stringify} from './util';
+
 
 
 /**
@@ -316,10 +318,8 @@ class ElementRef implements viewEngine.ElementRef {
  * @returns The TemplateRef instance to use
  */
 export function getOrCreateTemplateRef<T>(di: LNodeInjector): viewEngine.TemplateRef<T> {
+  ngDevMode && assertNodeType(di.node, LNodeFlags.Container);
   const data = (di.node as LContainer).data;
-  if (data === null || data.template === null) {
-    throw createInjectionError('Directive does not have a template.', null);
-  }
   return di.templateRef ||
       (di.templateRef = new TemplateRef<any>(getOrCreateElementRef(di), data.template));
 }
@@ -328,7 +328,7 @@ export function getOrCreateTemplateRef<T>(di: LNodeInjector): viewEngine.Templat
 class TemplateRef<T> implements viewEngine.TemplateRef<T> {
   readonly elementRef: viewEngine.ElementRef;
 
-  constructor(elementRef: viewEngine.ElementRef, template: ComponentTemplate<T>) {
+  constructor(elementRef: viewEngine.ElementRef, template: ComponentTemplate<T>|null) {
     this.elementRef = elementRef;
   }
 

--- a/packages/core/src/render3/interfaces.ts
+++ b/packages/core/src/render3/interfaces.ts
@@ -210,6 +210,14 @@ export interface ViewOrContainerState {
  */
 export type ProjectionState = Array<LElement|LText|LContainer>;
 
+/**
+ * An enum representing possible values of the "read" option for queries.
+ */
+export const enum QueryReadType {
+  ElementRef = 0,
+  ViewContainerRef = 1,
+  TemplateRef = 2,
+}
 
 /**
  * Used for tracking queries (e.g. ViewChild, ContentChild).
@@ -245,8 +253,11 @@ export interface QueryState {
    * @param queryList `QueryList` to update with changes.
    * @param predicate Either `Type` or selector array of [key, value] predicates.
    * @param descend If true the query will recursively apply to the children.
+   * @param read Indicates which token should be read from DI for this query.
    */
-  track<T>(queryList: QueryList<T>, predicate: Type<T>|any[], descend?: boolean): void;
+  track<T>(
+      queryList: QueryList<T>, predicate: Type<T>|string[], descend?: boolean,
+      read?: QueryReadType): void;
 }
 
 /**

--- a/packages/core/src/render3/node_assert.ts
+++ b/packages/core/src/render3/node_assert.ts
@@ -14,6 +14,17 @@ export function assertNodeType(node: LNode, type: LNodeFlags) {
   assertEqual(node.flags & LNodeFlags.TYPE_MASK, type, 'Node.type', typeSerializer);
 }
 
+export function assertNodeOfPossibleTypes(node: LNode, ...types: LNodeFlags[]) {
+  assertNotEqual(node, null, 'node');
+  const nodeType = (node.flags & LNodeFlags.TYPE_MASK);
+  for (let i = 0; i < types.length; i++) {
+    if (nodeType === types[i]) {
+      return;
+    }
+  }
+  throw new Error(
+      `Expected node of possible types: ${types.map(typeSerializer).join(', ')} but got ${typeSerializer(nodeType)}`);
+}
 
 function typeSerializer(type: LNodeFlags): string {
   if (type == LNodeFlags.Projection) return 'Projection';


### PR DESCRIPTION
This PR makes it possible to specify the `read` option for queries. The exact type to be red can be specified using a newly introduced `QueryReadType`. Most of the PRs code boils down to tests plus simple logic to return appropriate value (based on `QueryReadType`). Additionally there is a bug where container nodes were not considered by queries - this is fixed in this PR as well. 

