### PR TITLE
test(ivy): migrate styling tests from PR #34000

### DIFF
--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -161,12 +161,12 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
          }));
 
       it('should take initial classes into account when a reference changes', async(() => {
-            fixture = createTestComponent('<div class="foo" [ngClass]="arrExpr"></div>');
-            detectChangesAndExpectClassName('foo');
+           fixture = createTestComponent('<div class="foo" [ngClass]="arrExpr"></div>');
+           detectChangesAndExpectClassName('foo');
 
-            getComponent().arrExpr = ['bar'];
-            detectChangesAndExpectClassName('foo bar');
-          }));
+           getComponent().arrExpr = ['bar'];
+           detectChangesAndExpectClassName('foo bar');
+         }));
 
       it('should ignore empty or blank class names', async(() => {
            fixture = createTestComponent('<div class="foo" [ngClass]="arrExpr"></div>');
@@ -244,13 +244,13 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
          }));
 
       it('should take initial classes into account when switching from string to null',
-          async(() => {
-            fixture = createTestComponent(`<div class="foo" [ngClass]="strExpr"></div>`);
-            detectChangesAndExpectClassName('foo');
+         async(() => {
+           fixture = createTestComponent(`<div class="foo" [ngClass]="strExpr"></div>`);
+           detectChangesAndExpectClassName('foo');
 
-            getComponent().strExpr = null;
-            detectChangesAndExpectClassName('foo');
-          }));
+           getComponent().strExpr = null;
+           detectChangesAndExpectClassName('foo');
+         }));
 
       it('should ignore empty and blank strings', async(() => {
            fixture = createTestComponent(`<div class="foo" [ngClass]="strExpr"></div>`);
@@ -263,18 +263,18 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
     describe('cooperation with other class-changing constructs', () => {
 
       it('should co-operate with the class attribute', async(() => {
-            fixture = createTestComponent('<div [ngClass]="objExpr" class="init foo"></div>');
-            const objExpr = getComponent().objExpr;
+           fixture = createTestComponent('<div [ngClass]="objExpr" class="init foo"></div>');
+           const objExpr = getComponent().objExpr;
 
-            objExpr !['bar'] = true;
-            detectChangesAndExpectClassName('init foo bar');
+           objExpr !['bar'] = true;
+           detectChangesAndExpectClassName('init foo bar');
 
-            objExpr !['foo'] = false;
-            detectChangesAndExpectClassName('init bar');
+           objExpr !['foo'] = false;
+           detectChangesAndExpectClassName('init bar');
 
-            getComponent().objExpr = null;
-            detectChangesAndExpectClassName('init foo');
-          }));
+           getComponent().objExpr = null;
+           detectChangesAndExpectClassName('init foo');
+         }));
 
       it('should co-operate with the interpolated class attribute', async(() => {
            fixture = createTestComponent(`<div [ngClass]="objExpr" class="{{'init foo'}}"></div>`);
@@ -351,6 +351,31 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
            cmp.objExpr = null;
            detectChangesAndExpectClassName('init baz');
          }));
+    });
+
+    describe('non-regression', () => {
+
+      it('should allow classes with trailing and leading spaces in [ngClass]', () => {
+        @Component({
+          template: `
+            <div leading-space [ngClass]="{' foo': applyClasses}"></div>
+            <div trailing-space [ngClass]="{'foo ': applyClasses}"></div>
+          `
+        })
+        class Cmp {
+          applyClasses = true;
+        }
+
+        TestBed.configureTestingModule({declarations: [Cmp]});
+        const fixture = TestBed.createComponent(Cmp);
+        fixture.detectChanges();
+
+        const leading = fixture.nativeElement.querySelector('[leading-space]');
+        const trailing = fixture.nativeElement.querySelector('[trailing-space]');
+        expect(leading.className).toBe('foo');
+        expect(trailing.className).toBe('foo');
+      });
+
     });
   });
 }


### PR DESCRIPTION
This PR contains acceptance tests migrated from the PR #34000 (https://github.com/mhevery/angular/commits/pr_34000).

I did a number of modifications to the migrated tests. For the ones from https://github.com/mhevery/angular/commit/3555c1a198bb5a379fc5e12fe93fdef3fa3c510a:
* `should allow multiple styling bindings to work alongside property/attribute bindings` was migrated with slight modifications (removed bindings not used in asserts);
* `should allow host styling on the root element with external styling` was migrated as-is;
* `should apply camelCased classes` - migrated as `should apply camelCased class names` 
* `should apply camel-cased [style] properties` - migrated as `should convert camelCased style property names to snake-case`;
* `should recover from an error thrown in styling bindings` - was migrated with modifications (tighter asserts);
* `should apply template-level style bindings by writing to the style attribute directly` - there were 3 (!) tests with the same exact name and I migrated them as follows:

1. not migrated as was a low-level test asserting on the order of DOM manipulation (changed with Misko's implementation);
2. fixed (had a broken assert) and migrated as `should combine host class.foo bindings from multiple directives`;
3. migrated as `should combine static host classes with component "class" host attribute` 

https://github.com/mhevery/angular/commit/c77557534a272247172d545561f86cb37fa0ebd9	

Migrated 2 tests as `should allow a single style host binding on an element` and `should override class bindings when a directive extends another directive`

Some of the migrated tests are failing currently (ivy and / or VE) - more details in the in-line comments. So far I wasn't able to determine if a test or code is broken. Also some of the failures in VE are suspicious (looks like in practice there is a breaking change but I'm not sure we should have it....).